### PR TITLE
Add extension event catalog and Edge batching configuration

### DIFF
--- a/AEPEdge.xcodeproj/project.pbxproj
+++ b/AEPEdge.xcodeproj/project.pbxproj
@@ -26,12 +26,14 @@
 		216989652554B39900B2752C /* EdgeHit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 216989642554B39900B2752C /* EdgeHit.swift */; };
 		216989782554B61500B2752C /* EdgeHitProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 216989772554B61500B2752C /* EdgeHitProcessor.swift */; };
 		216989B32555376A00B2752C /* EdgeHitProcessorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 216989B22555376A00B2752C /* EdgeHitProcessorTests.swift */; };
+		BE3A74DB94CCBEDE9F4145DD /* EdgeBundledBatchingConfigTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E742414B220FB400B4D6FDE5 /* EdgeBundledBatchingConfigTests.swift */; };
+		5498316E0EF96A187C554E76 /* SharedStateReaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F7B22645DB9C48815995C56 /* SharedStateReaderTests.swift */; };
 		2198DEE22604F8BE008ADB6A /* Atomic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2198DEE12604F8BE008ADB6A /* Atomic.swift */; };
 		2198DEE826050458008ADB6A /* AtomicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2198DEE726050458008ADB6A /* AtomicTests.swift */; };
 		21C0F88A2627B9D9003872DC /* EdgeEndpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21C0F8892627B9D9003872DC /* EdgeEndpoint.swift */; };
 		21D7B7B22562F89C0010AE25 /* EdgeEventWarning.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21D7B7B12562F89C0010AE25 /* EdgeEventWarning.swift */; };
 		21FFBD5925631E3E00B48A8F /* EdgeEventWarningTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21FFBD5825631E3E00B48A8F /* EdgeEventWarningTests.swift */; };
-		21FFBD6C2563321600B48A8F /* EdgeEventErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21FFBD6B2563321600B48A8F /* EdgeEventErrorTests.swift */; };
+		21FFBD6C2563321600B48A8F /* EdgeResponseErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21FFBD6B2563321600B48A8F /* EdgeResponseErrorTests.swift */; };
 		2D291DA2D58DFDE34F9A607D /* EdgeBatchingHitQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24D4B4F8439125544300678E /* EdgeBatchingHitQueue.swift */; };
 		BADE531EF1F8BA6C24BF8818 /* EdgeBundledBatchingConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 314D898C6438199FBCA790A7 /* EdgeBundledBatchingConfig.swift */; };
 		2E1810032ACCB83F0067E444 /* ConfigOverrideTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E1810022ACCB83F0067E444 /* ConfigOverrideTests.swift */; };
@@ -105,8 +107,10 @@
 		D4C6B437251A76CB0038F4F9 /* XDMProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CCD27CF24592B2800E912B2 /* XDMProtocols.swift */; };
 		D4C6B438251A76CB0038F4F9 /* Edge+PublicAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4D5B4EA242EBB1600CAB6E4 /* Edge+PublicAPI.swift */; };
 		D4C6B43A251A76CB0038F4F9 /* ExperienceEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CCD27C52458CB2300E912B2 /* ExperienceEvent.swift */; };
-		D4C6B43C251A76CB0038F4F9 /* EdgeEventError.swift in Sources */ = {isa = PBXBuildFile; fileRef = D46553FA246B6FBC00A150E2 /* EdgeEventError.swift */; };
+		D4C6B43C251A76CB0038F4F9 /* EdgeResponseError.swift in Sources */ = {isa = PBXBuildFile; fileRef = D46553FA246B6FBC00A150E2 /* EdgeResponseError.swift */; };
 		D4C6B43D251A76CB0038F4F9 /* EdgeEventHandle.swift in Sources */ = {isa = PBXBuildFile; fileRef = D46553F8246B43B900A150E2 /* EdgeEventHandle.swift */; };
+		4A634C6534864EEB30CF5A69 /* EdgeEventError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68EF62435DADA4A4D8860D52 /* EdgeEventError.swift */; };
+		8A317937E7469F58CE8AD84C /* EdgeCallbackWithError.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE3157E3F5ECD3431FDBB351 /* EdgeCallbackWithError.swift */; };
 		D4C6B43E251A76CB0038F4F9 /* EdgeRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF947F77243BE16C0057A6CC /* EdgeRequest.swift */; };
 		D4C6B43F251A76CB0038F4F9 /* EdgeResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = D42FB8DA246261E600E9321C /* EdgeResponse.swift */; };
 		D4C6B440251A76CB0038F4F9 /* EdgeNetworkService.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4000F322459E2300052C536 /* EdgeNetworkService.swift */; };
@@ -224,12 +228,14 @@
 		216989642554B39900B2752C /* EdgeHit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EdgeHit.swift; sourceTree = "<group>"; };
 		216989772554B61500B2752C /* EdgeHitProcessor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EdgeHitProcessor.swift; sourceTree = "<group>"; };
 		216989B22555376A00B2752C /* EdgeHitProcessorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EdgeHitProcessorTests.swift; sourceTree = "<group>"; };
+		E742414B220FB400B4D6FDE5 /* EdgeBundledBatchingConfigTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EdgeBundledBatchingConfigTests.swift; sourceTree = "<group>"; };
+		3F7B22645DB9C48815995C56 /* SharedStateReaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedStateReaderTests.swift; sourceTree = "<group>"; };
 		2198DEE12604F8BE008ADB6A /* Atomic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Atomic.swift; sourceTree = "<group>"; };
 		2198DEE726050458008ADB6A /* AtomicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AtomicTests.swift; sourceTree = "<group>"; };
 		21C0F8892627B9D9003872DC /* EdgeEndpoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EdgeEndpoint.swift; sourceTree = "<group>"; };
 		21D7B7B12562F89C0010AE25 /* EdgeEventWarning.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EdgeEventWarning.swift; sourceTree = "<group>"; };
 		21FFBD5825631E3E00B48A8F /* EdgeEventWarningTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EdgeEventWarningTests.swift; sourceTree = "<group>"; };
-		21FFBD6B2563321600B48A8F /* EdgeEventErrorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EdgeEventErrorTests.swift; sourceTree = "<group>"; };
+		21FFBD6B2563321600B48A8F /* EdgeResponseErrorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EdgeResponseErrorTests.swift; sourceTree = "<group>"; };
 		24D4B4F8439125544300678E /* EdgeBatchingHitQueue.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = EdgeBatchingHitQueue.swift; sourceTree = "<group>"; };
 		314D898C6438199FBCA790A7 /* EdgeBundledBatchingConfig.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = EdgeBundledBatchingConfig.swift; sourceTree = "<group>"; };
 		2E1810022ACCB83F0067E444 /* ConfigOverrideTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigOverrideTests.swift; sourceTree = "<group>"; };
@@ -317,7 +323,9 @@
 		D45F2E8125EE1987000AC350 /* EdgePublicAPITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EdgePublicAPITests.swift; sourceTree = "<group>"; };
 		D46553F6246A384900A150E2 /* NetworkResponseHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkResponseHandlerTests.swift; sourceTree = "<group>"; };
 		D46553F8246B43B900A150E2 /* EdgeEventHandle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EdgeEventHandle.swift; sourceTree = "<group>"; };
-		D46553FA246B6FBC00A150E2 /* EdgeEventError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EdgeEventError.swift; sourceTree = "<group>"; };
+		68EF62435DADA4A4D8860D52 /* EdgeEventError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EdgeEventError.swift; sourceTree = "<group>"; };
+		EE3157E3F5ECD3431FDBB351 /* EdgeCallbackWithError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EdgeCallbackWithError.swift; sourceTree = "<group>"; };
+		D46553FA246B6FBC00A150E2 /* EdgeResponseError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EdgeResponseError.swift; sourceTree = "<group>"; };
 		D48CBD2124A17EEA00A24BD8 /* TestXDMSchema.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestXDMSchema.swift; sourceTree = "<group>"; };
 		D4967534251130D3001F5F95 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		D4A473C52485938D00D31710 /* TestConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestConstants.swift; sourceTree = "<group>"; };
@@ -492,7 +500,7 @@
 				D4145FD225DCB3890019EA4C /* ConsentEdgeHit.swift */,
 				D4145FCC25DCB3260019EA4C /* ExperienceEventsEdgeHit.swift */,
 				216989772554B61500B2752C /* EdgeHitProcessor.swift */,
-				D46553FA246B6FBC00A150E2 /* EdgeEventError.swift */,
+				D46553FA246B6FBC00A150E2 /* EdgeResponseError.swift */,
 				21D7B7B12562F89C0010AE25 /* EdgeEventWarning.swift */,
 				BF947F77243BE16C0057A6CC /* EdgeRequest.swift */,
 				D447C82025C3E85D00FE12E5 /* EdgeConsentUpdate.swift */,
@@ -525,6 +533,8 @@
 				D4D5B4EA242EBB1600CAB6E4 /* Edge+PublicAPI.swift */,
 				D46553F8246B43B900A150E2 /* EdgeEventHandle.swift */,
 				1CCD27C52458CB2300E912B2 /* ExperienceEvent.swift */,
+				68EF62435DADA4A4D8860D52 /* EdgeEventError.swift */,
+				EE3157E3F5ECD3431FDBB351 /* EdgeCallbackWithError.swift */,
 			);
 			name = public;
 			sourceTree = "<group>";
@@ -593,10 +603,12 @@
 				2198DEE726050458008ADB6A /* AtomicTests.swift */,
 				D4A81DEB25658F0D0042B00A /* CompletionHandlerTests.swift */,
 				BF7E5B3A2789189D00D5E0FF /* EdgeEndpointTests.swift */,
-				21FFBD6B2563321600B48A8F /* EdgeEventErrorTests.swift */,
+				21FFBD6B2563321600B48A8F /* EdgeResponseErrorTests.swift */,
 				21FFBD5825631E3E00B48A8F /* EdgeEventWarningTests.swift */,
 				D45F2E6F25ED8EE3000AC350 /* EdgeExtensionTests.swift */,
 				216989B22555376A00B2752C /* EdgeHitProcessorTests.swift */,
+				E742414B220FB400B4D6FDE5 /* EdgeBundledBatchingConfigTests.swift */,
+				3F7B22645DB9C48815995C56 /* SharedStateReaderTests.swift */,
 				D4145F3F25D1D3200019EA4C /* EdgeHitTests.swift */,
 				D4000F34245A53FB0052C536 /* EdgeNetworkServiceTests.swift */,
 				D45F2E8125EE1987000AC350 /* EdgePublicAPITests.swift */,
@@ -1287,11 +1299,13 @@
 				D4AB2D7B2808894800DC39CF /* QueryOptions.swift in Sources */,
 				2198DEE22604F8BE008ADB6A /* Atomic.swift in Sources */,
 				D4C6B43A251A76CB0038F4F9 /* ExperienceEvent.swift in Sources */,
-				D4C6B43C251A76CB0038F4F9 /* EdgeEventError.swift in Sources */,
+				D4C6B43C251A76CB0038F4F9 /* EdgeResponseError.swift in Sources */,
 				D447C82725C3EF0500FE12E5 /* EdgeConsentPayload.swift in Sources */,
 				D4145FB525D5D0430019EA4C /* Event+Edge.swift in Sources */,
 				2EC056EE2AB4F57100023BDE /* SDKConfig.swift in Sources */,
 				D4C6B43D251A76CB0038F4F9 /* EdgeEventHandle.swift in Sources */,
+				4A634C6534864EEB30CF5A69 /* EdgeEventError.swift in Sources */,
+				8A317937E7469F58CE8AD84C /* EdgeCallbackWithError.swift in Sources */,
 				D4C6B43E251A76CB0038F4F9 /* EdgeRequest.swift in Sources */,
 				BF74550D28BB18CD00FF3AEC /* EdgeProperties.swift in Sources */,
 				D43BAB0325BB758400B08CC0 /* EdgeConsentStatus.swift in Sources */,
@@ -1344,10 +1358,12 @@
 				D4F74FE92447A92800379258 /* MockURLSession.swift in Sources */,
 				D4145F4025D1D3200019EA4C /* EdgeHitTests.swift in Sources */,
 				216989B32555376A00B2752C /* EdgeHitProcessorTests.swift in Sources */,
+				BE3A74DB94CCBEDE9F4145DD /* EdgeBundledBatchingConfigTests.swift in Sources */,
+				5498316E0EF96A187C554E76 /* SharedStateReaderTests.swift in Sources */,
 				D4F74FEB2447A94900379258 /* MockTask.swift in Sources */,
 				D4000F35245A53FB0052C536 /* EdgeNetworkServiceTests.swift in Sources */,
 				D46553F7246A384900A150E2 /* NetworkResponseHandlerTests.swift in Sources */,
-				21FFBD6C2563321600B48A8F /* EdgeEventErrorTests.swift in Sources */,
+				21FFBD6C2563321600B48A8F /* EdgeResponseErrorTests.swift in Sources */,
 				BF7E5B3B2789189D00D5E0FF /* EdgeEndpointTests.swift in Sources */,
 				2198DEE826050458008ADB6A /* AtomicTests.swift in Sources */,
 				BFEEB5AB28D4E35D00B668B8 /* EdgePublicAPITests.swift in Sources */,

--- a/AEPEdge.xcodeproj/project.pbxproj
+++ b/AEPEdge.xcodeproj/project.pbxproj
@@ -33,6 +33,7 @@
 		21FFBD5925631E3E00B48A8F /* EdgeEventWarningTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21FFBD5825631E3E00B48A8F /* EdgeEventWarningTests.swift */; };
 		21FFBD6C2563321600B48A8F /* EdgeEventErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21FFBD6B2563321600B48A8F /* EdgeEventErrorTests.swift */; };
 		2D291DA2D58DFDE34F9A607D /* EdgeBatchingHitQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24D4B4F8439125544300678E /* EdgeBatchingHitQueue.swift */; };
+		BADE531EF1F8BA6C24BF8818 /* EdgeBundledBatchingConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 314D898C6438199FBCA790A7 /* EdgeBundledBatchingConfig.swift */; };
 		2E1810032ACCB83F0067E444 /* ConfigOverrideTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E1810022ACCB83F0067E444 /* ConfigOverrideTests.swift */; };
 		2E1810052ACCBA1B0067E444 /* TestEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E1810042ACCBA1B0067E444 /* TestEnvironment.swift */; };
 		2E1810072ACCE5B00067E444 /* TestBase+EdgeHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E1810062ACCE5B00067E444 /* TestBase+EdgeHelpers.swift */; };
@@ -230,6 +231,7 @@
 		21FFBD5825631E3E00B48A8F /* EdgeEventWarningTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EdgeEventWarningTests.swift; sourceTree = "<group>"; };
 		21FFBD6B2563321600B48A8F /* EdgeEventErrorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EdgeEventErrorTests.swift; sourceTree = "<group>"; };
 		24D4B4F8439125544300678E /* EdgeBatchingHitQueue.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = EdgeBatchingHitQueue.swift; sourceTree = "<group>"; };
+		314D898C6438199FBCA790A7 /* EdgeBundledBatchingConfig.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = EdgeBundledBatchingConfig.swift; sourceTree = "<group>"; };
 		2E1810022ACCB83F0067E444 /* ConfigOverrideTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigOverrideTests.swift; sourceTree = "<group>"; };
 		2E1810042ACCBA1B0067E444 /* TestEnvironment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestEnvironment.swift; sourceTree = "<group>"; };
 		2E1810062ACCE5B00067E444 /* TestBase+EdgeHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TestBase+EdgeHelpers.swift"; sourceTree = "<group>"; };
@@ -512,6 +514,7 @@
 				BFDF25AC2BDB077E002114B6 /* SharedStateReader.swift */,
 				24D4B4F8439125544300678E /* EdgeBatchingHitQueue.swift */,
 				D92F05877927388600B8DA62 /* BatchOutcome.swift */,
+				314D898C6438199FBCA790A7 /* EdgeBundledBatchingConfig.swift */,
 			);
 			path = EdgeNetworkHandlers;
 			sourceTree = "<group>";
@@ -1317,6 +1320,7 @@
 				D4C6B44E251A76CB0038F4F9 /* Edge.swift in Sources */,
 				2D291DA2D58DFDE34F9A607D /* EdgeBatchingHitQueue.swift in Sources */,
 				F523011B38819380501BF58A /* BatchOutcome.swift in Sources */,
+				BADE531EF1F8BA6C24BF8818 /* EdgeBundledBatchingConfig.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/AEPEdge.xcodeproj/project.pbxproj
+++ b/AEPEdge.xcodeproj/project.pbxproj
@@ -32,6 +32,7 @@
 		21D7B7B22562F89C0010AE25 /* EdgeEventWarning.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21D7B7B12562F89C0010AE25 /* EdgeEventWarning.swift */; };
 		21FFBD5925631E3E00B48A8F /* EdgeEventWarningTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21FFBD5825631E3E00B48A8F /* EdgeEventWarningTests.swift */; };
 		21FFBD6C2563321600B48A8F /* EdgeEventErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21FFBD6B2563321600B48A8F /* EdgeEventErrorTests.swift */; };
+		2D291DA2D58DFDE34F9A607D /* EdgeBatchingHitQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24D4B4F8439125544300678E /* EdgeBatchingHitQueue.swift */; };
 		2E1810032ACCB83F0067E444 /* ConfigOverrideTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E1810022ACCB83F0067E444 /* ConfigOverrideTests.swift */; };
 		2E1810052ACCBA1B0067E444 /* TestEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E1810042ACCBA1B0067E444 /* TestEnvironment.swift */; };
 		2E1810072ACCE5B00067E444 /* TestBase+EdgeHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E1810062ACCE5B00067E444 /* TestBase+EdgeHelpers.swift */; };
@@ -59,6 +60,8 @@
 		4CBEE6252A157CB40084BC50 /* SampleFunctionalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CBEE6242A157CB40084BC50 /* SampleFunctionalTests.swift */; };
 		4CF7915E2CA526AB003C1FD8 /* IntegrationTestConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CF7915D2CA526AB003C1FD8 /* IntegrationTestConstants.swift */; };
 		783A5F4E903F9B6EABA50D23 /* Pods_UnitTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5DA0155731FA82D43DA47B93 /* Pods_UnitTests.framework */; };
+		7C2745AEA9EC68DD877FE68B /* EdgeBatchingHitQueueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A321A42EE7CD7AC876A8BE8A /* EdgeBatchingHitQueueTests.swift */; };
+		AD7C4869E9DEACAFBC75A127 /* EdgeDataEntityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D0A46E5E96B2F3FFF4F9B26 /* EdgeDataEntityTests.swift */; };
 		BF024B7924C6238C002131E9 /* FakeIdentityExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF024B7824C6238C002131E9 /* FakeIdentityExtension.swift */; };
 		BF0C09482465E42100892B5D /* TestableEdge.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF0C09472465E42100892B5D /* TestableEdge.swift */; };
 		BF0F924F27476E6C00378913 /* ImplementationDetails.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF0F924E27476E6C00378913 /* ImplementationDetails.swift */; };
@@ -131,6 +134,7 @@
 		D4F74FEB2447A94900379258 /* MockTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4F74FEA2447A94900379258 /* MockTask.swift */; };
 		E97FFA8059E1B17324D8FFC6 /* Pods_AEPEdge.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D2E916ED29158164BF50EBF1 /* Pods_AEPEdge.framework */; };
 		F14D1687F07BBBB83A0A2C8E /* Pods_TestAppiOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 316EF062B0B622235F6BB384 /* Pods_TestAppiOS.framework */; };
+		F523011B38819380501BF58A /* BatchOutcome.swift in Sources */ = {isa = PBXBuildFile; fileRef = D92F05877927388600B8DA62 /* BatchOutcome.swift */; };
 		F906B76A0F7C19B9067533AC /* Pods_TestApptvOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F85212C814AA412355526B9F /* Pods_TestApptvOS.framework */; };
 		FCD6B046907107F7D83E41EF /* Pods_UpstreamIntegrationTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 773BC882A27A812B96D9C711 /* Pods_UpstreamIntegrationTests.framework */; };
 /* End PBXBuildFile section */
@@ -225,6 +229,7 @@
 		21D7B7B12562F89C0010AE25 /* EdgeEventWarning.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EdgeEventWarning.swift; sourceTree = "<group>"; };
 		21FFBD5825631E3E00B48A8F /* EdgeEventWarningTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EdgeEventWarningTests.swift; sourceTree = "<group>"; };
 		21FFBD6B2563321600B48A8F /* EdgeEventErrorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EdgeEventErrorTests.swift; sourceTree = "<group>"; };
+		24D4B4F8439125544300678E /* EdgeBatchingHitQueue.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = EdgeBatchingHitQueue.swift; sourceTree = "<group>"; };
 		2E1810022ACCB83F0067E444 /* ConfigOverrideTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigOverrideTests.swift; sourceTree = "<group>"; };
 		2E1810042ACCBA1B0067E444 /* TestEnvironment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestEnvironment.swift; sourceTree = "<group>"; };
 		2E1810062ACCE5B00067E444 /* TestBase+EdgeHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TestBase+EdgeHelpers.swift"; sourceTree = "<group>"; };
@@ -244,6 +249,7 @@
 		4CBEE6222A1577E40084BC50 /* NoConfigFunctionalTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NoConfigFunctionalTests.swift; sourceTree = "<group>"; };
 		4CBEE6242A157CB40084BC50 /* SampleFunctionalTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SampleFunctionalTests.swift; sourceTree = "<group>"; };
 		4CF7915D2CA526AB003C1FD8 /* IntegrationTestConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntegrationTestConstants.swift; sourceTree = "<group>"; };
+		5D0A46E5E96B2F3FFF4F9B26 /* EdgeDataEntityTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = EdgeDataEntityTests.swift; sourceTree = "<group>"; };
 		5DA0155731FA82D43DA47B93 /* Pods_UnitTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_UnitTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		5E8ABC044CA69B7B3B6DA2B8 /* Pods-UpstreamIntegrationTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-UpstreamIntegrationTests.debug.xcconfig"; path = "Target Support Files/Pods-UpstreamIntegrationTests/Pods-UpstreamIntegrationTests.debug.xcconfig"; sourceTree = "<group>"; };
 		7276A55D4B28344E8ED9D27B /* Pods-TestAppiOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TestAppiOS.debug.xcconfig"; path = "Target Support Files/Pods-TestAppiOS/Pods-TestAppiOS.debug.xcconfig"; sourceTree = "<group>"; };
@@ -252,6 +258,7 @@
 		85E2DC7CBF2801B140FC24A9 /* Pods-KonductorIntegrationTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-KonductorIntegrationTests.debug.xcconfig"; path = "Target Support Files/Pods-KonductorIntegrationTests/Pods-KonductorIntegrationTests.debug.xcconfig"; sourceTree = "<group>"; };
 		9CF4FC9E0341518F7ED94AED /* Pods-FunctionalTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-FunctionalTests.release.xcconfig"; path = "Target Support Files/Pods-FunctionalTests/Pods-FunctionalTests.release.xcconfig"; sourceTree = "<group>"; };
 		A03EED428A1ABF9130F3BECA /* Pods-TestApptvOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TestApptvOS.release.xcconfig"; path = "Target Support Files/Pods-TestApptvOS/Pods-TestApptvOS.release.xcconfig"; sourceTree = "<group>"; };
+		A321A42EE7CD7AC876A8BE8A /* EdgeBatchingHitQueueTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = EdgeBatchingHitQueueTests.swift; sourceTree = "<group>"; };
 		AF07B0197B2EA52E67BC99A6 /* Pods-KonductorIntegrationTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-KonductorIntegrationTests.release.xcconfig"; path = "Target Support Files/Pods-KonductorIntegrationTests/Pods-KonductorIntegrationTests.release.xcconfig"; sourceTree = "<group>"; };
 		B265C6B876BCBE382B6B8671 /* Pods-UnitTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-UnitTests.release.xcconfig"; path = "Target Support Files/Pods-UnitTests/Pods-UnitTests.release.xcconfig"; sourceTree = "<group>"; };
 		B2A0C5E6F49BE2565DF1CA65 /* Pods-TestApptvOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TestApptvOS.debug.xcconfig"; path = "Target Support Files/Pods-TestApptvOS/Pods-TestApptvOS.debug.xcconfig"; sourceTree = "<group>"; };
@@ -343,6 +350,7 @@
 		D4F74FE62447A8B800379258 /* MockNetworking.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockNetworking.swift; sourceTree = "<group>"; };
 		D4F74FE82447A92800379258 /* MockURLSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockURLSession.swift; sourceTree = "<group>"; };
 		D4F74FEA2447A94900379258 /* MockTask.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockTask.swift; sourceTree = "<group>"; };
+		D92F05877927388600B8DA62 /* BatchOutcome.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BatchOutcome.swift; sourceTree = "<group>"; };
 		ECE21024865660B5DB78AD82 /* Pods-E2EFunctionalTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-E2EFunctionalTests.release.xcconfig"; path = "Target Support Files/Pods-E2EFunctionalTests/Pods-E2EFunctionalTests.release.xcconfig"; sourceTree = "<group>"; };
 		F6293FCD59AB7997E527BB5A /* Pods_E2EFunctionalTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_E2EFunctionalTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		F85212C814AA412355526B9F /* Pods_TestApptvOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_TestApptvOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -502,6 +510,8 @@
 				BF947F85243F24570057A6CC /* StoreResponsePayload.swift */,
 				BF947F92244126D70057A6CC /* StoreResponsePayloadManager.swift */,
 				BFDF25AC2BDB077E002114B6 /* SharedStateReader.swift */,
+				24D4B4F8439125544300678E /* EdgeBatchingHitQueue.swift */,
+				D92F05877927388600B8DA62 /* BatchOutcome.swift */,
 			);
 			path = EdgeNetworkHandlers;
 			sourceTree = "<group>";
@@ -599,6 +609,8 @@
 				BF947F9424414E3E0057A6CC /* StoreResponsePayloadManagerTests.swift */,
 				BF947F87243F2EF70057A6CC /* StoreResponsePayloadTests.swift */,
 				D4D5B5252432599B00CAB6E4 /* Info.plist */,
+				A321A42EE7CD7AC876A8BE8A /* EdgeBatchingHitQueueTests.swift */,
+				5D0A46E5E96B2F3FFF4F9B26 /* EdgeDataEntityTests.swift */,
 			);
 			name = UnitTests;
 			path = Tests/UnitTests;
@@ -1303,6 +1315,8 @@
 				D4C6B44C251A76CB0038F4F9 /* StoreResponsePayloadManager.swift in Sources */,
 				D4C6B44D251A76CB0038F4F9 /* EdgeConstants.swift in Sources */,
 				D4C6B44E251A76CB0038F4F9 /* Edge.swift in Sources */,
+				2D291DA2D58DFDE34F9A607D /* EdgeBatchingHitQueue.swift in Sources */,
+				F523011B38819380501BF58A /* BatchOutcome.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1336,6 +1350,8 @@
 				D4A81DEC25658F0D0042B00A /* CompletionHandlerTests.swift in Sources */,
 				D4F74FE72447A8B800379258 /* MockNetworking.swift in Sources */,
 				1CCD27DC245A240F00E912B2 /* ExperienceEventTests.swift in Sources */,
+				7C2745AEA9EC68DD877FE68B /* EdgeBatchingHitQueueTests.swift in Sources */,
+				AD7C4869E9DEACAFBC75A127 /* EdgeDataEntityTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Sources/Edge+PublicAPI.swift
+++ b/Sources/Edge+PublicAPI.swift
@@ -39,6 +39,30 @@ public extension Edge {
         MobileCore.dispatch(event: event)
     }
 
+    /// Sends an event to Adobe Experience Edge and registers a callback for both responses and per-event errors
+    /// coming from the Edge Network.
+    /// - Parameters:
+    ///   - experienceEvent: Event to be sent to Adobe Experience Edge
+    ///   - callback: Optional callback invoked when the request is complete. `onComplete` is always invoked with
+    ///               the associated response handles received from the Adobe Experience Platform Edge Network;
+    ///               `onError` is additionally invoked if any errors were received for this event. May be invoked
+    ///               on a different thread.
+    @objc(sendExperienceEvent:callback:)
+    static func sendEvent(experienceEvent: ExperienceEvent, callback: EdgeCallbackWithError?) {
+        guard let xdmData = experienceEvent.xdm, !xdmData.isEmpty, let eventData = experienceEvent.asDictionary() else {
+            Log.debug(label: LOG_TAG, "Failed to dispatch the experience event because the XDM data was nil/empty.")
+            return
+        }
+
+        let event = Event(name: "AEP Request Event",
+                          type: EventType.edge,
+                          source: EventSource.requestContent,
+                          data: eventData)
+
+        CompletionHandlersManager.shared.registerErrorCallback(forRequestEventId: event.id.uuidString, callback: callback)
+        MobileCore.dispatch(event: event)
+    }
+
     /// Get the Edge Network location hint used in requests to the Adobe Experience Platform Edge Network.
     /// The Edge Network location hint may be used when building the URL for Adobe Experience Platform Edge Network requests to hint at the server cluster to use.
     /// Returns the Edge Network location hint, or nil if the location hint expired or is not set.

--- a/Sources/Edge.swift
+++ b/Sources/Edge.swift
@@ -132,10 +132,16 @@ public class Edge: NSObject, Extension {
             return // drop current event
         }
 
+        // Merge in the (possibly bundled-fallback) batching keys so they're snapshotted alongside the
+        // rest of the Edge configuration at enqueue time, same as edge.configId/environment/domain.
+        var combinedConfig: [String: Any] = edgeConfig
+        for (key, value) in sharedStateReader.getEdgeBatchingConfig(event: event) {
+            combinedConfig[key] = value
+        }
+
         let edgeEntity = EdgeDataEntity(event: event,
-                                        configuration: AnyCodable.from(dictionary: edgeConfig) ?? [:],
-                                        identityMap: AnyCodable.from(dictionary: identityState) ?? [:],
-                                        batchingEnabled: sharedStateReader.isBatchingEnabled(event: event))
+                                        configuration: AnyCodable.from(dictionary: combinedConfig) ?? [:],
+                                        identityMap: AnyCodable.from(dictionary: identityState) ?? [:])
 
         guard let entityData = try? JSONEncoder().encode(edgeEntity) else {
             Log.debug(label: EdgeConstants.LOG_TAG, "\(SELF_TAG) - Failed to encode EdgeDataEntity for event with id: '\(event.id.uuidString)'.")

--- a/Sources/Edge.swift
+++ b/Sources/Edge.swift
@@ -134,7 +134,8 @@ public class Edge: NSObject, Extension {
 
         let edgeEntity = EdgeDataEntity(event: event,
                                         configuration: AnyCodable.from(dictionary: edgeConfig) ?? [:],
-                                        identityMap: AnyCodable.from(dictionary: identityState) ?? [:])
+                                        identityMap: AnyCodable.from(dictionary: identityState) ?? [:],
+                                        batchingEnabled: sharedStateReader.isBatchingEnabled(event: event))
 
         guard let entityData = try? JSONEncoder().encode(edgeEntity) else {
             Log.debug(label: EdgeConstants.LOG_TAG, "\(SELF_TAG) - Failed to encode EdgeDataEntity for event with id: '\(event.id.uuidString)'.")
@@ -243,7 +244,7 @@ public class Edge: NSObject, Extension {
                                             readyForEvent: readyForEvent(_:),
                                             getImplementationDetails: getImplementationDetails,
                                             getLocationHint: getLocationHint)
-        return PersistentHitQueue(dataQueue: dataQueue, processor: hitProcessor)
+        return EdgeBatchingHitQueue(dataQueue: dataQueue, processor: hitProcessor)
     }
 
     /// Retrieves the `ConsentStatus` from the Consent XDM Shared state for current `event`.

--- a/Sources/EdgeCallbackWithError.swift
+++ b/Sources/EdgeCallbackWithError.swift
@@ -1,0 +1,30 @@
+//
+// Copyright 2026 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+//
+
+import Foundation
+
+/// A callback registered with `Edge.sendEvent(experienceEvent:callback:)` to receive both the response
+/// handles and any per-event errors for a sent Experience Event, mirroring `aepsdk-edge-android`'s
+/// `EdgeCallbackWithError`.
+@objc(AEPEdgeCallbackWithError)
+public protocol EdgeCallbackWithError: AnyObject {
+
+    /// Invoked when the request is complete, with the `EdgeEventHandle`(s) received from the Adobe
+    /// Experience Platform Edge Network for this event. May be invoked on a different thread. Always
+    /// invoked exactly once per registered event, regardless of whether any errors were also received.
+    func onComplete(_ handles: [EdgeEventHandle])
+
+    /// Invoked when one or more errors are received from the Adobe Experience Platform Edge Network for
+    /// this event. May be invoked on a different thread, and is only invoked when at least one error was
+    /// received - warnings do not trigger this callback.
+    func onError(_ errors: [EdgeEventError])
+}

--- a/Sources/EdgeConstants.swift
+++ b/Sources/EdgeConstants.swift
@@ -84,6 +84,8 @@ enum EdgeConstants {
             static let EDGE_DOMAIN = "edge.domain"
             // Matches aepsdk-edge-android's EdgeConstants.SharedState.Configuration.EDGE_BATCHING_ENABLED
             static let EDGE_BATCHING_ENABLED = "edge.batching.enabled"
+            // Matches aepsdk-edge-android's EdgeConstants.SharedState.Configuration.EDGE_BATCHING_EVENT_NAME_ALLOWLIST
+            static let EDGE_BATCHING_EVENT_NAME_ALLOWLIST = "edge.batching.eventNameAllowlist"
         }
 
         enum Identity {

--- a/Sources/EdgeConstants.swift
+++ b/Sources/EdgeConstants.swift
@@ -39,6 +39,8 @@ enum EdgeConstants {
         static let LOCATION_HINT_TTL_SEC: TimeInterval = 1800 // 30 mins in seconds
         // Matches aepsdk-edge-android's EdgeConstants.Defaults.MAX_BATCH_SIZE
         static let MAX_BATCH_SIZE: Int = 10
+        // Matches aepsdk-edge-android's EdgeConstants.Defaults.MAX_BATCH_SIZE_LIMIT
+        static let MAX_BATCH_SIZE_LIMIT: Int = 20
     }
 
     enum EventDataKeys {
@@ -86,6 +88,8 @@ enum EdgeConstants {
             static let EDGE_BATCHING_ENABLED = "edge.batching.enabled"
             // Matches aepsdk-edge-android's EdgeConstants.SharedState.Configuration.EDGE_BATCHING_EVENT_NAME_ALLOWLIST
             static let EDGE_BATCHING_EVENT_NAME_ALLOWLIST = "edge.batching.eventNameAllowlist"
+            // Matches aepsdk-edge-android's EdgeConstants.SharedState.Configuration.EDGE_BATCHING_MAX_BATCH_SIZE
+            static let EDGE_BATCHING_MAX_BATCH_SIZE = "edge.batching.maxBatchSize"
         }
 
         enum Identity {

--- a/Sources/EdgeConstants.swift
+++ b/Sources/EdgeConstants.swift
@@ -37,6 +37,8 @@ enum EdgeConstants {
         static let COLLECT_CONSENT_YES = ConsentStatus.yes // used if Consent extension is not registered
         static let COLLECT_CONSENT_PENDING = ConsentStatus.pending // used when Consent encoding failed or the value different than y/n
         static let LOCATION_HINT_TTL_SEC: TimeInterval = 1800 // 30 mins in seconds
+        // Matches aepsdk-edge-android's EdgeConstants.Defaults.MAX_BATCH_SIZE
+        static let MAX_BATCH_SIZE: Int = 10
     }
 
     enum EventDataKeys {
@@ -80,6 +82,8 @@ enum EdgeConstants {
             static let ORG_ID = "experienceCloud.org"
             static let EDGE_ENVIRONMENT = "edge.environment"
             static let EDGE_DOMAIN = "edge.domain"
+            // Matches aepsdk-edge-android's EdgeConstants.SharedState.Configuration.EDGE_BATCHING_ENABLED
+            static let EDGE_BATCHING_ENABLED = "edge.batching.enabled"
         }
 
         enum Identity {

--- a/Sources/EdgeEventError.swift
+++ b/Sources/EdgeEventError.swift
@@ -1,0 +1,51 @@
+//
+// Copyright 2026 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+//
+
+import Foundation
+
+/// Error information for a single Experience Event, delivered to an `EdgeCallbackWithError` registered via
+/// `Edge.sendEvent(experienceEvent:callback:)`, mirroring `aepsdk-edge-android`'s public `EdgeEventError`.
+@objc(AEPEdgeEventError)
+public class EdgeEventError: NSObject {
+
+    /// Namespaced error code
+    @objc public let type: String?
+
+    /// Error code info
+    @objc public let status: Int
+
+    /// Error message
+    @objc public let title: String?
+
+    /// Detailed message of the error
+    @objc public let detail: String?
+
+    init(type: String?, status: Int, title: String?, detail: String?) {
+        self.type = type
+        self.status = status
+        self.title = title
+        self.detail = detail
+    }
+
+    override public var description: String {
+        "EdgeEventError(type: \(type ?? "nil"), status: \(status), title: \(title ?? "nil"), detail: \(detail ?? "nil"))"
+    }
+}
+
+extension EdgeResponseError {
+    /// Projects this internal wire-format error onto the public `EdgeEventError` DTO, mirroring
+    /// `aepsdk-edge-android`'s `NetworkResponseHandler.buildEdgeEventError`. The internal `report`
+    /// (containing `eventIndex`, used only for response-to-event attribution) is intentionally dropped.
+    func asPublicEdgeEventError() -> EdgeEventError {
+        EdgeEventError(type: type, status: status ?? 0, title: title, detail: detail)
+    }
+}

--- a/Sources/EdgeNetworkHandlers/BatchOutcome.swift
+++ b/Sources/EdgeNetworkHandlers/BatchOutcome.swift
@@ -1,0 +1,34 @@
+//
+// Copyright 2026 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+//
+
+import Foundation
+
+/// Result returned by `EdgeHitProcessor.processBatch` to tell `EdgeBatchingHitQueue` how to advance
+/// the data queue after a batch attempt. Mirrors `aepsdk-edge-android`'s `BatchOutcome`.
+enum BatchOutcome {
+    /// The first `resolvedCount` entities (from the head) were resolved (delivered, dropped with
+    /// error, or ingested). Remove exactly that many from the queue — `processBatch` may have been
+    /// given a larger peeked window than it actually resolved (e.g. a window truncated at a
+    /// Consent/Reset/decode-failure boundary, or a single non-ExperienceEvent head processed alone);
+    /// only the resolved prefix is safe to dequeue. Anything beyond it was never sent and must stay
+    /// queued for the next cycle.
+    case done(resolvedCount: Int)
+
+    /// A recoverable network error occurred; nothing was ingested.
+    /// Leave the entire batch in the queue and retry after `retryInterval`.
+    case retryBatch(retryInterval: TimeInterval)
+
+    /// A 400 explosion partially resolved the batch from the head.
+    /// Remove the first `resolvedHeadCount` entities; leave the rest for the next cycle.
+    /// `retryInterval` is non-nil when the next unresolved entity needs a retry delay before the next cycle.
+    case partialRemove(resolvedHeadCount: Int, retryInterval: TimeInterval?)
+}

--- a/Sources/EdgeNetworkHandlers/CompletionHandlersManager.swift
+++ b/Sources/EdgeNetworkHandlers/CompletionHandlersManager.swift
@@ -22,6 +22,14 @@ class CompletionHandlersManager {
     private var edgeEventHandles =
         ThreadSafeDictionary<String, [EdgeEventHandle]>(identifier: "com.adobe.edge.edgeHandlesList")
 
+    // callbacks registered via `Edge.sendEvent(experienceEvent:callback:)`, keyed by request event id
+    private var errorCallbacks =
+        ThreadSafeDictionary<String, EdgeCallbackWithError>(identifier: "com.adobe.edge.errorCallbacks")
+
+    // edge event errors for a event request id (key)
+    private var edgeEventErrors =
+        ThreadSafeDictionary<String, [EdgeEventError]>(identifier: "com.adobe.edge.edgeEventErrorsList")
+
     static let shared = CompletionHandlersManager()
 
     /// Registers a completion handler for the specified `requestEventId`. This handler is invoked when the Edge response content has been
@@ -42,19 +50,53 @@ class CompletionHandlersManager {
         completionHandlers[forRequestEventId] = unwrappedCompletion
     }
 
+    /// Registers an `EdgeCallbackWithError` for the specified `requestEventId`. This callback's `onComplete` is
+    /// invoked when the Edge response content has been handled entirely by the Edge extension (identical timing
+    /// and contract to `registerCompletionHandler`); its `onError` is additionally invoked if any errors were
+    /// received for this event.
+    ///
+    /// - Parameters:
+    ///   - forRequestEventId: unique event identifier for which the callback is registered; should not be empty
+    ///   - callback: the callback that needs to be registered, should not be nil
+    func registerErrorCallback(forRequestEventId: String, callback: EdgeCallbackWithError?) {
+        guard let unwrappedCallback = callback else { return }
+        guard !forRequestEventId.isEmpty else {
+            Log.warning(label: TAG, "Failed to register error callback because of empty request event id.")
+            return
+        }
+
+        Log.trace(label: TAG, "Registering error callback for Edge response with request event id \(forRequestEventId).")
+        errorCallbacks[forRequestEventId] = unwrappedCallback
+    }
+
     /// Calls the registered completion handler (if any) with the collected `EdgeEventHandle`(s). After this operation,
-    /// the associated completion handler is removed and no longer called.
+    /// the associated completion handler is removed and no longer called. If an `EdgeCallbackWithError` is registered
+    /// for this request event id, its `onComplete` is invoked the same way, and its `onError` is additionally invoked
+    /// if any errors were accumulated for this event.
     /// - Parameter forRequestEventId: unique event identifier for experience events; should not be empty
     func unregisterCompletionHandler(forRequestEventId: String) {
         guard !forRequestEventId.isEmpty else { return }
 
+        let handles = edgeEventHandles[forRequestEventId] ?? []
+
         if let completionHandler = completionHandlers[forRequestEventId] {
-            completionHandler(edgeEventHandles[forRequestEventId] ?? [])
+            completionHandler(handles)
             _ = completionHandlers.removeValue(forKey: forRequestEventId)
             Log.trace(label: TAG, "Removing completion handler for Edge response with request event id \(forRequestEventId).")
         }
 
+        if let errorCallback = errorCallbacks[forRequestEventId] {
+            errorCallback.onComplete(handles)
+            let errors = edgeEventErrors[forRequestEventId] ?? []
+            if !errors.isEmpty {
+                errorCallback.onError(errors)
+            }
+            _ = errorCallbacks.removeValue(forKey: forRequestEventId)
+            Log.trace(label: TAG, "Removing error callback for Edge response with request event id \(forRequestEventId).")
+        }
+
         _ = edgeEventHandles.removeValue(forKey: forRequestEventId)
+        _ = edgeEventErrors.removeValue(forKey: forRequestEventId)
     }
 
     /// Updates the list of `EdgeEventHandle`(s) for current `requestEventId`.
@@ -67,6 +109,20 @@ class CompletionHandlersManager {
             edgeEventHandles[unwrappedRequestEventId]?.append(eventHandle)
         } else {
             edgeEventHandles[unwrappedRequestEventId] = [eventHandle]
+        }
+    }
+
+    /// Updates the list of `EdgeEventError`(s) for the current `requestEventId`, feeding the accumulated errors
+    /// delivered to a registered `EdgeCallbackWithError`'s `onError` when the request completes.
+    /// - Parameters:
+    ///   - forRequestEventId: the request event identifier associated with this error
+    ///   - error: newly received event error
+    func eventErrorReceived(forRequestEventId: String?, _ error: EdgeEventError) {
+        guard let unwrappedRequestEventId = forRequestEventId, !unwrappedRequestEventId.isEmpty else { return }
+        if edgeEventErrors[unwrappedRequestEventId] != nil {
+            edgeEventErrors[unwrappedRequestEventId]?.append(error)
+        } else {
+            edgeEventErrors[unwrappedRequestEventId] = [error]
         }
     }
 }

--- a/Sources/EdgeNetworkHandlers/EdgeBatchingHitQueue.swift
+++ b/Sources/EdgeNetworkHandlers/EdgeBatchingHitQueue.swift
@@ -145,7 +145,8 @@ class EdgeBatchingHitQueue: HitQueuing {
         guard let data = head.data, let edgeEntity = try? JSONDecoder().decode(EdgeDataEntity.self, from: data) else {
             return 1
         }
-        guard edgeEntity.batchingEnabled else { return 1 }
+        let batchingEnabled = edgeEntity.configuration.asAnyDictionary[EdgeConstants.SharedState.Configuration.EDGE_BATCHING_ENABLED] as? Bool ?? false
+        guard batchingEnabled else { return 1 }
         return min(dataQueue.count(), EdgeConstants.Defaults.MAX_BATCH_SIZE)
     }
 }

--- a/Sources/EdgeNetworkHandlers/EdgeBatchingHitQueue.swift
+++ b/Sources/EdgeNetworkHandlers/EdgeBatchingHitQueue.swift
@@ -21,7 +21,9 @@ import Foundation
 /// The effective batch size is determined at processing time from the head entity's snapshotted
 /// configuration:
 /// - batching disabled (default) -> window of 1, identical to `PersistentHitQueue`'s behavior.
-/// - batching enabled -> window of `min(queue.count(), MAX_BATCH_SIZE)`.
+/// - batching enabled -> window of `min(queue.count(), maxBatchSize)`, where `maxBatchSize` comes from
+///   the head entity's `edge.batching.maxBatchSize` value (falling back to `MAX_BATCH_SIZE` when absent
+///   or non-positive, clamped to `MAX_BATCH_SIZE_LIMIT` regardless of source).
 class EdgeBatchingHitQueue: HitQueuing {
     private let SELF_TAG = "EdgeBatchingHitQueue"
     let processor: HitProcessing
@@ -145,8 +147,19 @@ class EdgeBatchingHitQueue: HitQueuing {
         guard let data = head.data, let edgeEntity = try? JSONDecoder().decode(EdgeDataEntity.self, from: data) else {
             return 1
         }
-        let batchingEnabled = edgeEntity.configuration.asAnyDictionary[EdgeConstants.SharedState.Configuration.EDGE_BATCHING_ENABLED] as? Bool ?? false
+        let config = edgeEntity.configuration.asAnyDictionary
+        let batchingEnabled = config[EdgeConstants.SharedState.Configuration.EDGE_BATCHING_ENABLED] as? Bool ?? false
         guard batchingEnabled else { return 1 }
-        return min(dataQueue.count(), EdgeConstants.Defaults.MAX_BATCH_SIZE)
+        return min(dataQueue.count(), Self.maxBatchSize(from: config))
+    }
+
+    /// Resolves the configured `edge.batching.maxBatchSize`, mirroring
+    /// `aepsdk-edge-android`'s `EdgeBatchingHitQueue.getMaxBatchSize`: a value that is absent or
+    /// non-positive falls back to `MAX_BATCH_SIZE` (unclamped); a positive value is clamped only on the
+    /// high side to `MAX_BATCH_SIZE_LIMIT`.
+    private static func maxBatchSize(from config: [String: Any]) -> Int {
+        let configured = config[EdgeConstants.SharedState.Configuration.EDGE_BATCHING_MAX_BATCH_SIZE] as? Int ?? EdgeConstants.Defaults.MAX_BATCH_SIZE
+        guard configured > 0 else { return EdgeConstants.Defaults.MAX_BATCH_SIZE }
+        return min(configured, EdgeConstants.Defaults.MAX_BATCH_SIZE_LIMIT)
     }
 }

--- a/Sources/EdgeNetworkHandlers/EdgeBatchingHitQueue.swift
+++ b/Sources/EdgeNetworkHandlers/EdgeBatchingHitQueue.swift
@@ -1,0 +1,151 @@
+//
+// Copyright 2026 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+//
+
+import AEPServices
+import Foundation
+
+/// Batch-capable hit queue for the Edge extension. Uses the same `DataQueue` persistence and serial
+/// `DispatchQueue` pattern as `PersistentHitQueue`, but processes a window of entities per cycle when
+/// batching is enabled (`edge.batching.enabled = true`), mirroring `aepsdk-edge-android`'s
+/// `EdgeBatchingHitQueue`.
+///
+/// The effective batch size is determined at processing time from the head entity's snapshotted
+/// configuration:
+/// - batching disabled (default) -> window of 1, identical to `PersistentHitQueue`'s behavior.
+/// - batching enabled -> window of `min(queue.count(), MAX_BATCH_SIZE)`.
+class EdgeBatchingHitQueue: HitQueuing {
+    private let SELF_TAG = "EdgeBatchingHitQueue"
+    let processor: HitProcessing
+    private let edgeHitProcessor: EdgeHitProcessor
+    private let dataQueue: DataQueue
+
+    private var suspended = true
+    private var isTaskScheduled = false
+    private let queue = DispatchQueue(label: "com.adobe.edge.batchingHitQueue")
+
+    init(dataQueue: DataQueue, processor: EdgeHitProcessor) {
+        self.dataQueue = dataQueue
+        self.edgeHitProcessor = processor
+        self.processor = processor
+    }
+
+    @discardableResult
+    func queue(entity: DataEntity) -> Bool {
+        let result = dataQueue.add(dataEntity: entity)
+        processNextBatch()
+        return result
+    }
+
+    func beginProcessing() {
+        queue.async { self.suspended = false }
+        processNextBatch()
+    }
+
+    func suspend() {
+        queue.async { self.suspended = true }
+    }
+
+    func clear() {
+        _ = dataQueue.clear()
+    }
+
+    func count() -> Int {
+        return dataQueue.count()
+    }
+
+    func close() {
+        suspend()
+        dataQueue.close()
+    }
+
+    /// Schedules one batch-processing cycle if none is already running. Mirrors the guard in
+    /// `PersistentHitQueue.processNextHit()`.
+    private func processNextBatch() {
+        queue.async {
+            guard !self.suspended, !self.isTaskScheduled else { return }
+            guard let head = self.dataQueue.peek() else { return } // nothing left in the queue, stop processing
+
+            let batchSize = self.effectiveBatchSize(for: head)
+            let entities: [DataEntity]
+            if batchSize > 1, let peeked = self.dataQueue.peek(n: batchSize), !peeked.isEmpty {
+                entities = peeked
+            } else {
+                entities = [head]
+            }
+
+            self.isTaskScheduled = true
+            self.edgeHitProcessor.processBatch(entities: entities) { [weak self] outcome in
+                guard let self = self else { return }
+                self.handleOutcome(outcome, batchCount: entities.count)
+            }
+        }
+    }
+
+    private func handleOutcome(_ outcome: BatchOutcome, batchCount: Int) {
+        switch outcome {
+        case .done(let resolvedCount):
+            // Remove only what processBatch actually resolved — it may have been given a larger
+            // peeked window than it acted on (truncation at a Consent/Reset/decode-failure boundary,
+            // or a single non-ExperienceEvent head processed alone), and anything beyond the resolved
+            // prefix was never sent, so it must stay queued for the next cycle.
+            queue.async {
+                guard resolvedCount > 0 else {
+                    self.isTaskScheduled = false
+                    self.processNextBatch()
+                    return
+                }
+                if self.dataQueue.remove(n: resolvedCount) {
+                    self.isTaskScheduled = false
+                    self.processNextBatch()
+                } else {
+                    Log.warning(label: self.SELF_TAG, "An unexpected error occurred while attempting to delete records from the database. Data processing will be paused.")
+                }
+            }
+
+        case .retryBatch(let retryInterval):
+            Log.trace(label: self.SELF_TAG, "Batch of \(batchCount) will be retried in \(retryInterval) seconds.")
+            queue.asyncAfter(deadline: .now() + retryInterval) { [weak self] in
+                guard let self = self else { return }
+                self.isTaskScheduled = false
+                self.processNextBatch()
+            }
+
+        case .partialRemove(let resolvedHeadCount, let retryInterval):
+            queue.async {
+                if resolvedHeadCount > 0 {
+                    _ = self.dataQueue.remove(n: resolvedHeadCount)
+                }
+                if let retryInterval = retryInterval {
+                    Log.trace(label: self.SELF_TAG, "Partial removal of \(resolvedHeadCount) entities; next entity needs retry in \(retryInterval) seconds.")
+                    self.queue.asyncAfter(deadline: .now() + retryInterval) { [weak self] in
+                        guard let self = self else { return }
+                        self.isTaskScheduled = false
+                        self.processNextBatch()
+                    }
+                } else {
+                    self.isTaskScheduled = false
+                    self.processNextBatch()
+                }
+            }
+        }
+    }
+
+    /// Returns the number of entities to include in the next batch, based on the `edge.batching.enabled`
+    /// flag snapshotted in the head entity's configuration.
+    private func effectiveBatchSize(for head: DataEntity) -> Int {
+        guard let data = head.data, let edgeEntity = try? JSONDecoder().decode(EdgeDataEntity.self, from: data) else {
+            return 1
+        }
+        guard edgeEntity.batchingEnabled else { return 1 }
+        return min(dataQueue.count(), EdgeConstants.Defaults.MAX_BATCH_SIZE)
+    }
+}

--- a/Sources/EdgeNetworkHandlers/EdgeBundledBatchingConfig.swift
+++ b/Sources/EdgeNetworkHandlers/EdgeBundledBatchingConfig.swift
@@ -13,12 +13,12 @@
 import AEPServices
 import Foundation
 
-/// Loads a first-launch fallback for the Edge batching configuration keys (`edge.batching.enabled` and
-/// `edge.batching.eventNameAllowlist`) from a JSON file bundled in the app, mirroring
-/// `aepsdk-edge-android`'s `EdgeBundledBatchingConfig`.
+/// Loads a first-launch fallback for the Edge batching configuration keys (`edge.batching.enabled`,
+/// `edge.batching.eventNameAllowlist`, and `edge.batching.maxBatchSize`) from a JSON file bundled in the
+/// app, mirroring `aepsdk-edge-android`'s `EdgeBundledBatchingConfig`.
 ///
 /// This is a per-key fallback, not a wholesale configuration replacement: `SharedStateReader.getEdgeBatchingConfig`
-/// consults this bundled file only for whichever of the two batching keys is absent from the Configuration shared
+/// consults this bundled file only for whichever of the batching keys is absent from the Configuration shared
 /// state at the time an event is queued. Any key present in the Configuration shared state - whether set
 /// programmatically via `MobileCore.updateConfiguration()` or delivered by a remote/Launch-published configuration -
 /// always takes precedence over the bundled file's value for that same key.
@@ -59,7 +59,7 @@ enum EdgeBundledBatchingConfig {
     }
 
     private static func load() -> [String: Any] {
-        guard let content = ServiceProvider.shared.systemInfoService.getAsset(fileName: BUNDLED_CONFIG_FILE_NAME, fileType: BUNDLED_CONFIG_FILE_TYPE),
+        guard let content: String = ServiceProvider.shared.systemInfoService.getAsset(fileName: BUNDLED_CONFIG_FILE_NAME, fileType: BUNDLED_CONFIG_FILE_TYPE),
               !content.isEmpty else {
             Log.trace(label: EdgeConstants.LOG_TAG,
                       "\(SELF_TAG) - No bundled batching config file '\(BUNDLED_CONFIG_FILE_NAME).\(BUNDLED_CONFIG_FILE_TYPE)' found; skipping.")

--- a/Sources/EdgeNetworkHandlers/EdgeBundledBatchingConfig.swift
+++ b/Sources/EdgeNetworkHandlers/EdgeBundledBatchingConfig.swift
@@ -1,0 +1,80 @@
+//
+// Copyright 2026 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+//
+
+import AEPServices
+import Foundation
+
+/// Loads a first-launch fallback for the Edge batching configuration keys (`edge.batching.enabled` and
+/// `edge.batching.eventNameAllowlist`) from a JSON file bundled in the app, mirroring
+/// `aepsdk-edge-android`'s `EdgeBundledBatchingConfig`.
+///
+/// This is a per-key fallback, not a wholesale configuration replacement: `SharedStateReader.getEdgeBatchingConfig`
+/// consults this bundled file only for whichever of the two batching keys is absent from the Configuration shared
+/// state at the time an event is queued. Any key present in the Configuration shared state - whether set
+/// programmatically via `MobileCore.updateConfiguration()` or delivered by a remote/Launch-published configuration -
+/// always takes precedence over the bundled file's value for that same key.
+enum EdgeBundledBatchingConfig {
+    private static let SELF_TAG = "EdgeBundledBatchingConfig"
+
+    /// Name (without extension) of the JSON file expected in the app bundle.
+    static let BUNDLED_CONFIG_FILE_NAME = "adb_edgeBatchingConfig"
+    static let BUNDLED_CONFIG_FILE_TYPE = "json"
+
+    private static let loadLock = NSLock()
+    private static var cachedConfig: [String: Any]?
+    private static var loadAttempted = false
+
+    /// Returns the parsed contents of the bundled batching config file, loading and caching it the
+    /// first time this is called. Subsequent calls return the cached result without re-reading the
+    /// file. Returns an empty dictionary (never nil) if the file is missing, empty, or malformed.
+    static func get() -> [String: Any] {
+        loadLock.lock()
+        defer { loadLock.unlock() }
+
+        if !loadAttempted {
+            cachedConfig = load()
+            loadAttempted = true
+        }
+
+        return cachedConfig ?? [:]
+    }
+
+    /// Clears the cached result so the next call to `get()` re-reads the bundled file.
+    /// Test-only; production code should never need to force a re-read.
+    static func resetForTesting() {
+        loadLock.lock()
+        defer { loadLock.unlock() }
+
+        cachedConfig = nil
+        loadAttempted = false
+    }
+
+    private static func load() -> [String: Any] {
+        guard let content = ServiceProvider.shared.systemInfoService.getAsset(fileName: BUNDLED_CONFIG_FILE_NAME, fileType: BUNDLED_CONFIG_FILE_TYPE),
+              !content.isEmpty else {
+            Log.trace(label: EdgeConstants.LOG_TAG,
+                      "\(SELF_TAG) - No bundled batching config file '\(BUNDLED_CONFIG_FILE_NAME).\(BUNDLED_CONFIG_FILE_TYPE)' found; skipping.")
+            return [:]
+        }
+
+        guard let data = content.data(using: .utf8),
+              let jsonObject = try? JSONSerialization.jsonObject(with: data),
+              let parsed = jsonObject as? [String: Any] else {
+            Log.warning(label: EdgeConstants.LOG_TAG,
+                        "\(SELF_TAG) - Failed to parse bundled batching config file '\(BUNDLED_CONFIG_FILE_NAME).\(BUNDLED_CONFIG_FILE_TYPE)'.")
+            return [:]
+        }
+
+        Log.debug(label: EdgeConstants.LOG_TAG, "\(SELF_TAG) - Loaded bundled batching config from '\(BUNDLED_CONFIG_FILE_NAME).\(BUNDLED_CONFIG_FILE_TYPE)': \(parsed)")
+        return parsed
+    }
+}

--- a/Sources/EdgeNetworkHandlers/EdgeDataEntity.swift
+++ b/Sources/EdgeNetworkHandlers/EdgeDataEntity.swift
@@ -19,36 +19,20 @@ struct EdgeDataEntity: Codable {
     /// The `Event` responsible for the hit
     let event: Event
 
-    /// The current configuration shared state at the time `Event` was queued
+    /// The current configuration shared state at the time `Event` was queued. May also contain the
+    /// `edge.batching.enabled`/`edge.batching.eventNameAllowlist` keys snapshotted at enqueue time
+    /// (see `SharedStateReader.getEdgeBatchingConfig`).
     let configuration: [String: AnyCodable]
 
     /// The current identity shared state at the time `Event` was queued
     let identityMap: [String: AnyCodable]
+}
 
-    /// Whether batching was enabled (via the `edge.batching.enabled` Configuration flag) at the time `Event` was queued
-    let batchingEnabled: Bool
-
-    init(event: Event, configuration: [String: AnyCodable], identityMap: [String: AnyCodable], batchingEnabled: Bool = false) {
-        self.event = event
-        self.configuration = configuration
-        self.identityMap = identityMap
-        self.batchingEnabled = batchingEnabled
-    }
-
-    private enum CodingKeys: String, CodingKey {
-        case event
-        case configuration
-        case identityMap
-        case batchingEnabled
-    }
-
-    // Custom decoder so hits persisted before `batchingEnabled` was introduced (no such key in their
-    // stored JSON) still decode successfully, defaulting to `false` instead of failing the whole hit.
-    init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-        event = try container.decode(Event.self, forKey: .event)
-        configuration = try container.decode([String: AnyCodable].self, forKey: .configuration)
-        identityMap = try container.decode([String: AnyCodable].self, forKey: .identityMap)
-        batchingEnabled = (try? container.decode(Bool.self, forKey: .batchingEnabled)) ?? false
+extension Dictionary where Key == String, Value == AnyCodable {
+    /// This dictionary's values unwrapped as `[String: Any]`, dropping any `nil` `AnyCodable` values.
+    /// Used to safely read individually-typed keys (e.g. batching config flags) out of a heterogeneous
+    /// snapshot without risking a blanket `as? [String: T]` cast failing because of unrelated keys.
+    var asAnyDictionary: [String: Any] {
+        AnyCodable.toAnyDictionary(dictionary: self) ?? [:]
     }
 }

--- a/Sources/EdgeNetworkHandlers/EdgeDataEntity.swift
+++ b/Sources/EdgeNetworkHandlers/EdgeDataEntity.swift
@@ -24,4 +24,31 @@ struct EdgeDataEntity: Codable {
 
     /// The current identity shared state at the time `Event` was queued
     let identityMap: [String: AnyCodable]
+
+    /// Whether batching was enabled (via the `edge.batching.enabled` Configuration flag) at the time `Event` was queued
+    let batchingEnabled: Bool
+
+    init(event: Event, configuration: [String: AnyCodable], identityMap: [String: AnyCodable], batchingEnabled: Bool = false) {
+        self.event = event
+        self.configuration = configuration
+        self.identityMap = identityMap
+        self.batchingEnabled = batchingEnabled
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case event
+        case configuration
+        case identityMap
+        case batchingEnabled
+    }
+
+    // Custom decoder so hits persisted before `batchingEnabled` was introduced (no such key in their
+    // stored JSON) still decode successfully, defaulting to `false` instead of failing the whole hit.
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        event = try container.decode(Event.self, forKey: .event)
+        configuration = try container.decode([String: AnyCodable].self, forKey: .configuration)
+        identityMap = try container.decode([String: AnyCodable].self, forKey: .identityMap)
+        batchingEnabled = (try? container.decode(Bool.self, forKey: .batchingEnabled)) ?? false
+    }
 }

--- a/Sources/EdgeNetworkHandlers/EdgeHitProcessor.swift
+++ b/Sources/EdgeNetworkHandlers/EdgeHitProcessor.swift
@@ -62,8 +62,11 @@ class EdgeHitProcessor: HitProcessing {
 
         // Check which workflow is used to obtain configuration
         if !edgeEntity.configuration.isEmpty {
-            // Current workflow includes needed configuration in EdgeDataEntity before queuing hit
-            edgeConfig = AnyCodable.toAnyDictionary(dictionary: edgeEntity.configuration) as? [String: String] ?? [:]
+            // Current workflow includes needed configuration in EdgeDataEntity before queuing hit.
+            // configuration may also carry non-String batching keys (edge.batching.enabled/eventNameAllowlist),
+            // so pull out only the String-valued entries instead of a blanket cast that would fail entirely
+            // the moment a non-String key is present.
+            edgeConfig = edgeEntity.configuration.asAnyDictionary.compactMapValues { $0 as? String }
         } else {
             // Older workflow is supported in cases where persisted hits were queued before upgrade, but processed after upgrade
             // These hits will not have configuration in EdgeDataEntity, so the Configuration shared state is queried
@@ -213,10 +216,12 @@ class EdgeHitProcessor: HitProcessing {
     ///
     /// Routing rules mirror `aepsdk-edge-android`'s `EdgeHitProcessor.processBatch`:
     /// - Head is not an ExperienceEvent (Consent, Reset) -> process head alone.
+    /// - Head's event name is not in the `edge.batching.eventNameAllowlist` snapshotted at enqueue time
+    ///   -> process head alone (opt-in allowlist: `edge.batching.enabled` alone is not sufficient).
     /// - Batch size == 1 (or only the head qualifies) -> single-entity path.
-    /// - Multiple consecutive ExperienceEvents -> build one batch request; on 400, explode to individual
-    ///   sends (nothing was ingested, so every event is safe to resend); on other unrecoverable errors,
-    ///   drop all (matches the single-event path's existing behavior for the same codes).
+    /// - Multiple consecutive, allowlisted ExperienceEvents -> build one batch request; on 400, explode
+    ///   to individual sends (nothing was ingested, so every event is safe to resend); on other
+    ///   unrecoverable errors, drop all (matches the single-event path's existing behavior for the same codes).
     /// - Parameters:
     ///   - entities: ordered list of entities to process; must not be empty
     ///   - completion: completion handler invoked with a `BatchOutcome` describing how the queue should advance
@@ -238,11 +243,21 @@ class EdgeHitProcessor: HitProcessing {
             return
         }
 
+        // Events whose name isn't in the configured allowlist must also be processed alone.
+        guard isEventNameAllowlistedForBatching(headEdgeEntity) else {
+            Log.trace(label: EdgeConstants.LOG_TAG,
+                      "\(SELF_TAG) - Head entity's event name (\(headEdgeEntity.event.name)) is not in the batching allowlist; processing alone.")
+            processSingleEntity(headEntity, completion: completion)
+            return
+        }
+
         // Collect the consecutive ExperienceEvent run from the front.
         var batchEntities: [DataEntity] = []
         var batchEvents: [Event] = []
         for dataEntity in entities {
-            guard let edgeEntity = decode(dataEntity: dataEntity), edgeEntity.event.isExperienceEvent else {
+            guard let edgeEntity = decode(dataEntity: dataEntity),
+                  edgeEntity.event.isExperienceEvent,
+                  isEventNameAllowlistedForBatching(edgeEntity) else {
                 break
             }
             batchEntities.append(dataEntity)
@@ -267,7 +282,10 @@ class EdgeHitProcessor: HitProcessing {
             requestBuilder.xdmPayloads[EdgeConstants.JsonKeys.IMPLEMENTATION_DETAILS] = AnyCodable(implementationDetails)
         }
 
-        let edgeConfig = AnyCodable.toAnyDictionary(dictionary: headEdgeEntity.configuration) as? [String: String] ?? [:]
+        // configuration may also carry non-String batching keys (edge.batching.enabled/eventNameAllowlist),
+        // so pull out only the String-valued entries instead of a blanket cast that would fail entirely
+        // the moment a non-String key is present.
+        let edgeConfig = headEdgeEntity.configuration.asAnyDictionary.compactMapValues { $0 as? String }
         guard var datastreamId = edgeConfig[EdgeConstants.SharedState.Configuration.CONFIG_ID], !datastreamId.isEmpty else {
             Log.debug(label: EdgeConstants.LOG_TAG,
                       "\(SELF_TAG) - Cannot process batch: Edge config ID is missing or empty, dropping \(batchEntities.count) events.")
@@ -308,6 +326,18 @@ class EdgeHitProcessor: HitProcessing {
                     headers: getRequestHeaders(headEvent),
                     batchEntities: batchEntities,
                     completion: completion)
+    }
+
+    /// Checks whether `entity`'s underlying `Event` name is present in the `edge.batching.eventNameAllowlist`
+    /// configuration snapshotted on this entity at enqueue time. An absent or empty allowlist means no event
+    /// names are eligible for batching (opt-in allowlist semantics) - `edge.batching.enabled` alone is not
+    /// sufficient to batch a given event. Mirrors `aepsdk-edge-android`'s `EdgeHitProcessor.isEventNameAllowlistedForBatching`.
+    private func isEventNameAllowlistedForBatching(_ entity: EdgeDataEntity) -> Bool {
+        guard let allowlist = entity.configuration.asAnyDictionary[EdgeConstants.SharedState.Configuration.EDGE_BATCHING_EVENT_NAME_ALLOWLIST] as? [String],
+              !allowlist.isEmpty else {
+            return false
+        }
+        return allowlist.contains(entity.event.name)
     }
 
     /// Delegates a single `DataEntity` to the existing `processHit` path and converts the boolean

--- a/Sources/EdgeNetworkHandlers/EdgeHitProcessor.swift
+++ b/Sources/EdgeNetworkHandlers/EdgeHitProcessor.swift
@@ -257,7 +257,8 @@ class EdgeHitProcessor: HitProcessing {
         for dataEntity in entities {
             guard let edgeEntity = decode(dataEntity: dataEntity),
                   edgeEntity.event.isExperienceEvent,
-                  isEventNameAllowlistedForBatching(edgeEntity) else {
+                  isEventNameAllowlistedForBatching(edgeEntity),
+                  hasSameRequestConfig(edgeEntity, headEdgeEntity) else {
                 break
             }
             batchEntities.append(dataEntity)
@@ -338,6 +339,28 @@ class EdgeHitProcessor: HitProcessing {
             return false
         }
         return allowlist.contains(entity.event.name)
+    }
+
+    /// Checks whether `candidate` shares the same request-building config as `head` - the full snapshotted
+    /// Configuration map (datastream ID, environment, domain, batching keys) and the event-level `config`
+    /// overrides (`datastreamIdOverride`/`datastreamConfigOverride`). A single batch request is built
+    /// entirely from the head's config, so an entity with a different snapshot must not be silently folded
+    /// in - it would lose its own datastream/override and get sent under the head's instead. Mirrors
+    /// `aepsdk-edge-android`'s `EdgeHitProcessor.hasSameRequestConfig`.
+    ///
+    /// Compares via `NSDictionary` bridging rather than `AnyCodable`'s own `==`, since `AnyCodable.==`
+    /// only recognizes array/dictionary values typed exactly as `[AnyCodable]`/`[String: AnyCodable]` -
+    /// `edge.batching.eventNameAllowlist` decodes to a plain `[Any?]`, which falls through to `AnyCodable`'s
+    /// `default: return false` and would make this always report "different config" whenever an allowlist
+    /// is present, defeating batching entirely.
+    private func hasSameRequestConfig(_ candidate: EdgeDataEntity, _ head: EdgeDataEntity) -> Bool {
+        let candidateConfig = AnyCodable.toAnyDictionary(dictionary: candidate.configuration) ?? [:]
+        let headConfig = AnyCodable.toAnyDictionary(dictionary: head.configuration) ?? [:]
+        guard (candidateConfig as NSDictionary).isEqual(to: headConfig) else { return false }
+
+        let candidateOverrides = candidate.event.config ?? [:]
+        let headOverrides = head.event.config ?? [:]
+        return (candidateOverrides as NSDictionary).isEqual(to: headOverrides)
     }
 
     /// Delegates a single `DataEntity` to the existing `processHit` path and converts the boolean

--- a/Sources/EdgeNetworkHandlers/EdgeHitProcessor.swift
+++ b/Sources/EdgeNetworkHandlers/EdgeHitProcessor.swift
@@ -208,6 +208,194 @@ class EdgeHitProcessor: HitProcessing {
         sendHit(entityId: entityId, edgeHit: edgeHit, headers: getRequestHeaders(event), completion: completion)
     }
 
+    /// Processes a batch of `DataEntity`s as a single network request when the batch contains more than
+    /// one ExperienceEvent; otherwise delegates to the existing single-entity `processHit` path.
+    ///
+    /// Routing rules mirror `aepsdk-edge-android`'s `EdgeHitProcessor.processBatch`:
+    /// - Head is not an ExperienceEvent (Consent, Reset) -> process head alone.
+    /// - Batch size == 1 (or only the head qualifies) -> single-entity path.
+    /// - Multiple consecutive ExperienceEvents -> build one batch request; on 400, explode to individual
+    ///   sends (nothing was ingested, so every event is safe to resend); on other unrecoverable errors,
+    ///   drop all (matches the single-event path's existing behavior for the same codes).
+    /// - Parameters:
+    ///   - entities: ordered list of entities to process; must not be empty
+    ///   - completion: completion handler invoked with a `BatchOutcome` describing how the queue should advance
+    func processBatch(entities: [DataEntity], completion: @escaping (BatchOutcome) -> Void) {
+        guard let headEntity = entities.first else {
+            completion(.done(resolvedCount: 0))
+            return
+        }
+
+        guard let headEdgeEntity = decode(dataEntity: headEntity) else {
+            Log.debug(label: EdgeConstants.LOG_TAG, "\(SELF_TAG) - Unable to decode head entity to EdgeDataEntity, dropping.")
+            completion(.done(resolvedCount: 1))
+            return
+        }
+
+        guard headEdgeEntity.event.isExperienceEvent else {
+            // Non-experience events (consent, reset) must be processed alone.
+            processSingleEntity(headEntity, completion: completion)
+            return
+        }
+
+        // Collect the consecutive ExperienceEvent run from the front.
+        var batchEntities: [DataEntity] = []
+        var batchEvents: [Event] = []
+        for dataEntity in entities {
+            guard let edgeEntity = decode(dataEntity: dataEntity), edgeEntity.event.isExperienceEvent else {
+                break
+            }
+            batchEntities.append(dataEntity)
+            batchEvents.append(edgeEntity.event)
+        }
+
+        guard batchEntities.count > 1 else {
+            processSingleEntity(headEntity, completion: completion)
+            return
+        }
+
+        Log.debug(label: EdgeConstants.LOG_TAG, "\(SELF_TAG) - Processing batch of \(batchEntities.count) ExperienceEvent(s).")
+
+        let requestBuilder = RequestBuilder()
+        let identityState = AnyCodable.toAnyDictionary(dictionary: headEdgeEntity.identityMap)
+        requestBuilder.xdmPayloads[EdgeConstants.SharedState.Identity.IDENTITY_MAP] =
+            AnyCodable(identityState?[EdgeConstants.SharedState.Identity.IDENTITY_MAP])
+        requestBuilder.enableResponseStreaming(recordSeparator: EdgeConstants.Defaults.RECORD_SEPARATOR,
+                                               lineFeed: EdgeConstants.Defaults.LINE_FEED)
+
+        if let implementationDetails = getImplementationDetails() {
+            requestBuilder.xdmPayloads[EdgeConstants.JsonKeys.IMPLEMENTATION_DETAILS] = AnyCodable(implementationDetails)
+        }
+
+        let edgeConfig = AnyCodable.toAnyDictionary(dictionary: headEdgeEntity.configuration) as? [String: String] ?? [:]
+        guard var datastreamId = edgeConfig[EdgeConstants.SharedState.Configuration.CONFIG_ID], !datastreamId.isEmpty else {
+            Log.debug(label: EdgeConstants.LOG_TAG,
+                      "\(SELF_TAG) - Cannot process batch: Edge config ID is missing or empty, dropping \(batchEntities.count) events.")
+            completion(.done(resolvedCount: batchEntities.count))
+            return
+        }
+
+        let headEvent = headEdgeEntity.event
+        if let datastreamIdOverride = headEvent.config?[EdgeConstants.EventDataKeys.Config.DATASTREAM_ID_OVERRIDE] as? String, !datastreamIdOverride.isEmpty {
+            requestBuilder.sdkConfig = SDKConfig(datastream: Datastream(original: datastreamId))
+            datastreamId = datastreamIdOverride
+        }
+        if let datastreamConfigOverride = headEvent.config?[EdgeConstants.EventDataKeys.Config.DATASTREAM_CONFIG_OVERRIDE] as? [String: Any], !datastreamConfigOverride.isEmpty {
+            requestBuilder.configOverrides = AnyCodable.from(dictionary: datastreamConfigOverride)
+        }
+
+        guard let requestPayload = requestBuilder.getPayloadWithExperienceEvents(batchEvents) else {
+            Log.warning(label: EdgeConstants.LOG_TAG,
+                        "\(SELF_TAG) - Failed to build the batch request payload, dropping \(batchEntities.count) events.")
+            completion(.done(resolvedCount: batchEntities.count))
+            return
+        }
+
+        let requestProperties = getRequestProperties(from: headEvent)
+        let locationHint = getLocationHint()
+        let endpoint = buildEdgeEndpoint(config: edgeConfig,
+                                         requestType: EdgeRequestType.interact,
+                                         requestProperties: requestProperties,
+                                         locationHint: locationHint)
+        let edgeHit = ExperienceEventsEdgeHit(endpoint: endpoint, datastreamId: datastreamId, request: requestPayload)
+
+        // NOTE: the order of these events needs to be maintained as they were sent in the network request
+        // otherwise the response callback cannot be matched
+        networkResponseHandler.addWaitingEvents(requestId: edgeHit.requestId, batchedEvents: batchEvents)
+
+        sendBatchHit(entityId: headEntity.uniqueIdentifier,
+                    edgeHit: edgeHit,
+                    headers: getRequestHeaders(headEvent),
+                    batchEntities: batchEntities,
+                    completion: completion)
+    }
+
+    /// Delegates a single `DataEntity` to the existing `processHit` path and converts the boolean
+    /// result to a `BatchOutcome`.
+    private func processSingleEntity(_ entity: DataEntity, completion: @escaping (BatchOutcome) -> Void) {
+        processHit(entity: entity) { [weak self] success in
+            if success {
+                completion(.done(resolvedCount: 1))
+            } else {
+                completion(.retryBatch(retryInterval: self?.retryInterval(for: entity) ?? EdgeConstants.Defaults.RETRY_INTERVAL))
+            }
+        }
+    }
+
+    /// Sends a batch network request. The response is buffered (not forwarded to `networkResponseHandler`)
+    /// until the HTTP response code is known, so a 400 (nothing ingested) can be exploded into individual
+    /// resends without first delivering a phantom, misattributed error or firing premature completions for
+    /// the whole batch. Every other outcome is forwarded to `networkResponseHandler` unchanged, in the same
+    /// order it was received, exactly reproducing the single-event path's existing behavior.
+    private func sendBatchHit(entityId: String, edgeHit: EdgeHit, headers: [String: String], batchEntities: [DataEntity], completion: @escaping (BatchOutcome) -> Void) {
+        guard let url = networkService.buildUrl(endpoint: edgeHit.endpoint, datastreamId: edgeHit.datastreamId, requestId: edgeHit.requestId) else {
+            Log.debug(label: EdgeConstants.LOG_TAG,
+                      "\(SELF_TAG) - Failed to build the URL, dropping batch request with id '\(edgeHit.requestId)'.")
+            completion(.done(resolvedCount: batchEntities.count))
+            return
+        }
+
+        let buffering = BufferingResponseCallback()
+        networkService.doRequest(url: url,
+                                 requestBody: edgeHit.getPayload(),
+                                 requestHeaders: headers,
+                                 streaming: edgeHit.getStreamingSettings(),
+                                 responseCallback: buffering) { [weak self] success, retryInterval, responseCode in
+            guard let self = self else { return }
+
+            guard success else {
+                self.entityRetryIntervalMapping[entityId] = retryInterval
+                completion(.retryBatch(retryInterval: retryInterval ?? EdgeConstants.Defaults.RETRY_INTERVAL))
+                return
+            }
+
+            self.entityRetryIntervalMapping[entityId] = nil
+
+            if responseCode == HttpResponseCodes.badRequest.rawValue {
+                Log.warning(label: EdgeConstants.LOG_TAG,
+                            "\(self.SELF_TAG) - Batch of \(batchEntities.count) events received 400; nothing ingested, exploding to individual requests.")
+                // Discard the buffered onError/onComplete: the batch's waiting events were registered
+                // under edgeHit.requestId, but since nothing was ingested, remove that registration
+                // without dispatching so the individual resends (new request ids) own the completions.
+                _ = self.networkResponseHandler.removeWaitingEvents(requestId: edgeHit.requestId)
+                self.explodeAndResend(remaining: batchEntities, resolvedCount: 0, completion: completion)
+            } else {
+                buffering.replay(into: self.networkResponseHandler, requestId: edgeHit.requestId)
+                completion(.done(resolvedCount: batchEntities.count))
+            }
+        }
+    }
+
+    /// Re-sends each entity in `batchEntities` individually after a batch 400. A 400 means nothing in the
+    /// batch was ingested, so every event is safe to resend. Entities are processed FIFO: a `.done` outcome
+    /// counts as resolved; a `.retryBatch` (recoverable failure) stops the explosion and returns the
+    /// resolved count so the queue can remove those entities and schedule a retry for the remainder.
+    private func explodeAndResend(remaining: [DataEntity], resolvedCount: Int, completion: @escaping (BatchOutcome) -> Void) {
+        guard let entity = remaining.first else {
+            completion(.done(resolvedCount: resolvedCount))
+            return
+        }
+
+        // Each entity is sent as a batch-of-1, which goes through the same terminal path (handles
+        // success, drop, and the existing single-event 400 behavior).
+        processSingleEntity(entity) { [weak self] outcome in
+            guard let self = self else { return }
+            switch outcome {
+            case .done:
+                self.explodeAndResend(remaining: Array(remaining.dropFirst()), resolvedCount: resolvedCount + 1, completion: completion)
+            case .retryBatch(let retryInterval):
+                if resolvedCount > 0 {
+                    completion(.partialRemove(resolvedHeadCount: resolvedCount, retryInterval: retryInterval))
+                } else {
+                    completion(.retryBatch(retryInterval: retryInterval))
+                }
+            case .partialRemove:
+                // Not reachable: a size-1 `processSingleEntity` call never returns `.partialRemove`.
+                self.explodeAndResend(remaining: Array(remaining.dropFirst()), resolvedCount: resolvedCount + 1, completion: completion)
+            }
+        }
+    }
+
     /// Builds the endpoint based on the provided config info and `EdgeRequestType`
     /// - Parameters:
     ///   - config: configuration data, used to extract the environment and the custom domain, if any
@@ -255,7 +443,7 @@ class EdgeHitProcessor: HitProcessing {
                                  requestBody: edgeHit.getPayload(),
                                  requestHeaders: headers,
                                  streaming: edgeHit.getStreamingSettings(),
-                                 responseCallback: callback) { [weak self] success, retryInterval in
+                                 responseCallback: callback) { [weak self] success, retryInterval, _ in
             if let self = self {
                 // remove any retry interval if success, otherwise add to retry mapping
                 self.entityRetryIntervalMapping[entityId] = success ? nil : retryInterval
@@ -324,5 +512,45 @@ class EdgeHitProcessor: HitProcessing {
         let regex = try? NSRegularExpression(pattern: pattern, options: [])
         let matches = regex?.firstMatch(in: path, range: NSRange(path.startIndex..., in: path)) != nil
         return matches
+    }
+}
+
+/// Buffers `ResponseCallback` invocations (in the order received) instead of forwarding them immediately,
+/// so `EdgeHitProcessor.sendBatchHit` can inspect the HTTP response code before deciding whether to
+/// replay them into `NetworkResponseHandler` or discard them (400 batch explosion).
+private class BufferingResponseCallback: ResponseCallback {
+    private enum BufferedCall {
+        case response(String)
+        case error(String)
+    }
+
+    private var calls: [BufferedCall] = []
+    private var completeCalled = false
+
+    func onResponse(jsonResponse: String) {
+        calls.append(.response(jsonResponse))
+    }
+
+    func onError(jsonError: String) {
+        calls.append(.error(jsonError))
+    }
+
+    func onComplete() {
+        completeCalled = true
+    }
+
+    /// Forwards every buffered call to `networkResponseHandler`, in the original order, for `requestId`.
+    func replay(into networkResponseHandler: NetworkResponseHandler, requestId: String) {
+        for call in calls {
+            switch call {
+            case .response(let jsonResponse):
+                networkResponseHandler.processResponseOnSuccess(jsonResponse: jsonResponse, requestId: requestId)
+            case .error(let jsonError):
+                networkResponseHandler.processResponseOnError(jsonError: jsonError, requestId: requestId)
+            }
+        }
+        if completeCalled {
+            networkResponseHandler.processResponseOnComplete(requestId: requestId)
+        }
     }
 }

--- a/Sources/EdgeNetworkHandlers/EdgeNetworkService.swift
+++ b/Sources/EdgeNetworkHandlers/EdgeNetworkService.swift
@@ -278,7 +278,7 @@ class EdgeNetworkService {
         var unwrappedErrorMessage = plainTextErrorMessage ?? DEFAULT_GENERIC_ERROR_MESSAGE
         unwrappedErrorMessage = unwrappedErrorMessage.trimmingCharacters(in: .whitespacesAndNewlines)
 
-        let eventError = EdgeEventError(title: DEFAULT_GENERIC_ERROR_TITLE, detail: unwrappedErrorMessage)
+        let eventError = EdgeResponseError(title: DEFAULT_GENERIC_ERROR_TITLE, detail: unwrappedErrorMessage)
 
         guard let json = try? JSONEncoder().encode(eventError) else {
             Log.debug(label: EdgeConstants.LOG_TAG, "\(SELF_TAG) - Failed to serialize the error message.")

--- a/Sources/EdgeNetworkHandlers/EdgeNetworkService.swift
+++ b/Sources/EdgeNetworkHandlers/EdgeNetworkService.swift
@@ -26,6 +26,7 @@ enum EdgeRequestType: String {
 enum HttpResponseCodes: Int {
     case ok = 200
     case noContent = 204
+    case badRequest = 400
     case multiStatus = 207
     case tooManyRequests = 429
     case badGateway = 502
@@ -71,17 +72,21 @@ class EdgeNetworkService {
     ///   - requestBody: `EdgeRequest` containing the encoded events
     ///   - requestHeaders: request HTTP headers
     ///   - responseCallback: `ResponseCallback` to be invoked once the server response is received
-    ///   - completion: a closure that is invoked with true if the hit should not be retried, false if the hit should be retried, along with the time interval that should elapse before retrying the hit
+    ///   - completion: a closure invoked with true if the hit should not be retried, false if the hit should be retried, along with
+    ///     the time interval that should elapse before retrying the hit, and the HTTP response code if one was received (nil if the
+    ///     request never reached the server, e.g. malformed URL or empty body). The response code lets callers that batch multiple
+    ///     events into one request (see `EdgeHitProcessor.processBatch`) distinguish a 400 (nothing ingested, safe to resend each
+    ///     event individually) from other unrecoverable errors (deliver the terminal error once, don't resend).
     func doRequest(url: URL,
                    requestBody: String?,
                    requestHeaders: [String: String]? = [:],
                    streaming: Streaming?,
                    responseCallback: ResponseCallback,
-                   completion: @escaping (Bool, TimeInterval?) -> Void) {
+                   completion: @escaping (Bool, TimeInterval?, Int?) -> Void) {
         guard let payload = requestBody, !payload.isEmpty else {
             Log.warning(label: EdgeConstants.LOG_TAG, "\(SELF_TAG) - Request body is nil/empty, dropping this request")
             responseCallback.onComplete()
-            completion(true, nil)
+            completion(true, nil, nil)
             return
         }
 
@@ -106,7 +111,7 @@ class EdgeNetworkService {
                        Log.debug(label: EdgeConstants.LOG_TAG,
                                  "\(self.SELF_TAG) - Edge request with url:\(url.absoluteString) \(errorMessage)). Will retry request in \(retryInterval) seconds.")
 
-                       completion(false, retryInterval) // failed, but recoverable so retry
+                       completion(false, retryInterval, nil) // failed, but recoverable so retry
                        return
                 }
 
@@ -116,7 +121,7 @@ class EdgeNetworkService {
                             "\(self.SELF_TAG) - Edge request with url:\(url.absoluteString) \(errorMessage). Dropping the request.")
                 self.handleError(connection: connection, responseCallback: responseCallback)
                 responseCallback.onComplete()
-                completion(true, nil) // don't retry
+                completion(true, nil, connection.responseCode) // don't retry
                 return
             }
 
@@ -124,7 +129,7 @@ class EdgeNetworkService {
                 Log.warning(label: EdgeConstants.LOG_TAG, "\(self.SELF_TAG) - Edge request with url:\(url.absoluteString) failed with unknown error. Dropping the request.")
                 self.handleError(connection: connection, responseCallback: responseCallback)
                 responseCallback.onComplete()
-                completion(true, nil) // failed, but unrecoverable, don't retry
+                completion(true, nil, nil) // failed, but unrecoverable, don't retry
                 return
             }
 
@@ -191,7 +196,7 @@ class EdgeNetworkService {
                                     connection: HttpConnection,
                                     streaming: Streaming?,
                                     responseCallback: ResponseCallback,
-                                    completion: @escaping (Bool, TimeInterval?) -> Void) {
+                                    completion: @escaping (Bool, TimeInterval?, Int?) -> Void) {
 
         switch responseCode {
         case HttpResponseCodes.ok.rawValue:
@@ -200,11 +205,11 @@ class EdgeNetworkService {
                                streaming: streaming,
                                responseCallback: responseCallback)
             responseCallback.onComplete()
-            completion(true, nil) // successful request, return true
+            completion(true, nil, responseCode) // successful request, return true
         case HttpResponseCodes.noContent.rawValue:
             Log.debug(label: EdgeConstants.LOG_TAG, "\(SELF_TAG) - Connection to Experience Edge was successful, no content returned.")
             responseCallback.onComplete()
-            completion(true, nil) // successful request, return true
+            completion(true, nil, responseCode) // successful request, return true
         case HttpResponseCodes.multiStatus.rawValue:
             Log.debug(label: EdgeConstants.LOG_TAG,
                       "\(SELF_TAG) - Connection to Experience Edge was successful, but encountered non-fatal errors/warnings. \(responseCode)")
@@ -212,7 +217,7 @@ class EdgeNetworkService {
                                streaming: streaming,
                                responseCallback: responseCallback)
             responseCallback.onComplete()
-            completion(true, nil) // non-fatal error, don't retry
+            completion(true, nil, responseCode) // non-fatal error, don't retry
         default:
             if self.recoverableNetworkErrorCodes.contains(responseCode) {
                 let retryHeader = connection.responseHttpHeader(forKey: EdgeConstants.NetworkKeys.HEADER_KEY_RETRY_AFTER)
@@ -223,12 +228,12 @@ class EdgeNetworkService {
                 }
                 Log.debug(label: EdgeConstants.LOG_TAG,
                           "\(SELF_TAG) - Connection to Experience Edge returned recoverable error code \(responseCode). Will retry request in \(retryInterval) seconds.")
-                completion(false, retryInterval) // failed, but recoverable so retry
+                completion(false, retryInterval, responseCode) // failed, but recoverable so retry
             } else {
                 Log.warning(label: EdgeConstants.LOG_TAG, "\(SELF_TAG) - Connection to Experience Edge returned unrecoverable error code \(responseCode)")
                 self.handleError(connection: connection, responseCallback: responseCallback)
                 responseCallback.onComplete()
-                completion(true, nil) // failed, but unrecoverable, don't retry
+                completion(true, nil, responseCode) // failed, but unrecoverable, don't retry
             }
         }
     }

--- a/Sources/EdgeNetworkHandlers/EdgeResponse.swift
+++ b/Sources/EdgeNetworkHandlers/EdgeResponse.swift
@@ -23,7 +23,7 @@ struct EdgeResponse: Codable {
     let handle: [EdgeEventHandle]?
 
     /// List of errors received from Experience Edge Network
-    let errors: [EdgeEventError]?
+    let errors: [EdgeResponseError]?
 
     /// List of warnings received from Experience Edge Network
     let warnings: [EdgeEventWarning]?

--- a/Sources/EdgeNetworkHandlers/EdgeResponseError.swift
+++ b/Sources/EdgeNetworkHandlers/EdgeResponseError.swift
@@ -13,7 +13,7 @@
 import Foundation
 
 /// Error information for a sent EdgeRequest
-struct EdgeEventError: Codable, Equatable {
+struct EdgeResponseError: Codable, Equatable {
     /// Error message
     let title: String?
 

--- a/Sources/EdgeNetworkHandlers/NetworkResponseHandler.swift
+++ b/Sources/EdgeNetworkHandlers/NetworkResponseHandler.swift
@@ -136,7 +136,7 @@ class NetworkResponseHandler {
         }
     }
 
-    /// Decodes the response as `EdgeResponse` and extracts the errors if possible, otherwise decodes it as `EdgeEventError` and dispatches error events for the errors/warnings
+    /// Decodes the response as `EdgeResponse` and extracts the errors if possible, otherwise decodes it as `EdgeResponseError` and dispatches error events for the errors/warnings
     /// received from the server.
     /// - Parameters:
     ///   - jsonError: JSON formatted error response received from the server
@@ -148,7 +148,7 @@ class NetworkResponseHandler {
         if let edgeResponse = try? JSONDecoder().decode(EdgeResponse.self, from: data), edgeResponse.errors != nil {
             // this is an error coming from Konductor, read the error from the errors node
             dispatchEventErrors(errorsArray: edgeResponse.errors, requestId: requestId)
-        } else if let edgeErrorResponse = try? JSONDecoder().decode(EdgeEventError.self, from: data) {
+        } else if let edgeErrorResponse = try? JSONDecoder().decode(EdgeResponseError.self, from: data) {
             // generic server error, return the error as is
             dispatchEventErrors(errorsArray: [edgeErrorResponse], requestId: requestId)
         } else {
@@ -322,7 +322,7 @@ class NetworkResponseHandler {
     /// Extracts the request event paired with this event handle/error handle based on the index. If no match is found, this method returns nil.
     ///
     /// - Parameters:
-    ///   - forEventIndex: the `EdgeEventHandle`/ `EdgeEventError` event index
+    ///   - forEventIndex: the `EdgeEventHandle`/ `EdgeResponseError` event index
     ///   - requestId: edge request id used to fetch the waiting events associated with it (if any)
     /// - Returns: the request event for which this event handle was received, nil if not found
     private func extractRequestEvent(forEventIndex eventIndex: Int, requestId: String) -> Event? {
@@ -409,10 +409,10 @@ class NetworkResponseHandler {
     /// Iterates over the provided `errorsArray` and dispatches a new error event to the Event Hub.
     /// It also logs each error json with the log level error.
     /// - Parameters:
-    ///   - errorsArray: `EdgeEventError` array containing all the event errors to be processed
+    ///   - errorsArray: `EdgeResponseError` array containing all the event errors to be processed
     ///   - requestId: the event request identifier, used for logging
     /// - See Also: `logErrorMessage(_ error: [String: Any], isError: Bool, requestId: String)`
-    private func dispatchEventErrors(errorsArray: [EdgeEventError]?, requestId: String) {
+    private func dispatchEventErrors(errorsArray: [EdgeResponseError]?, requestId: String) {
         guard let unwrappedErrors = errorsArray, !unwrappedErrors.isEmpty else {
             Log.trace(label: LOG_TAG, "dispatchEventErrors - Received nil/empty errors array, nothing to handle")
             return
@@ -432,6 +432,8 @@ class NetworkResponseHandler {
                     sweepCompletions(requestId: requestId, exclusiveUpperBound: eventIndex)
                 }
 
+                let publicEdgeEventError = error.asPublicEdgeEventError()
+
                 // A root-level (no-index) error on a batch of N>1 events is fanned out to every waiting
                 // event, since any of them could be the one that actually failed.
                 for requestEvent in resolveErrorRequestEvents(eventIndex: eventIndex, requestId: requestId) {
@@ -441,6 +443,7 @@ class NetworkResponseHandler {
                                                                      requestEventId: requestEvent?.id.uuidString)
                     guard !eventData.isEmpty else { continue }
                     dispatchResponseEventWithData(eventData, parentRequestEvent: requestEvent, isErrorResponseEvent: true, eventSource: nil)
+                    CompletionHandlersManager.shared.eventErrorReceived(forRequestEventId: requestEvent?.id.uuidString, publicEdgeEventError)
                 }
             }
         }
@@ -579,7 +582,7 @@ class NetworkResponseHandler {
     /// - If isError is true, the message is logged as error.
     /// - If isError is false, the message is logged as warning.
     /// - Parameters:
-    ///   - error: `EdgeEventError` encoded as [String: Any] containing the event error/warning coming from server
+    ///   - error: `EdgeResponseError` encoded as [String: Any] containing the event error/warning coming from server
     ///   - isError: boolean indicating if this is an error message
     ///   - requestId: the event request identifier, used for logging
     private func logErrorMessage(_ error: [String: Any], isError: Bool, requestId: String) {

--- a/Sources/EdgeNetworkHandlers/NetworkResponseHandler.swift
+++ b/Sources/EdgeNetworkHandlers/NetworkResponseHandler.swift
@@ -23,8 +23,23 @@ class NetworkResponseHandler {
     private let dataStore = NamedCollectionDataStore(name: EdgeConstants.EXTENSION_NAME)
     private var updateLocationHint: (String, _ ttlSeconds: TimeInterval) -> Void
 
+    /// Behaviour switch for early per-event completion (index-advance), mirroring
+    /// `aepsdk-edge-android`'s `NetworkResponseHandler.earlyPerEventCompletionEnabled`. When `true`
+    /// (default), a batched event's completion fires as soon as a response fragment for a higher
+    /// `eventIndex` is observed (all lower-index events are then known complete), instead of waiting
+    /// for the whole batch's stream to close. The highest index and anything still pending complete
+    /// at stream close (`processResponseOnComplete`), exactly as before. Only relevant to multi-event
+    /// batched responses; single events, consent, batch-of-1 are unaffected either way.
+    static var earlyPerEventCompletionEnabled = true
+
     // the order of the request events matter for matching them with the response events
     private var sentEventsWaitingResponse = ThreadSafeDictionary<String, [Event]>()
+
+    // early-completion progress, keyed by requestId: highest eventIndex observed in the response so far
+    private var highestObservedIndex = ThreadSafeDictionary<String, Int>()
+    // early-completion progress, keyed by requestId: number of leading events already completed
+    // (monotonic; guarantees each event completes exactly once)
+    private var nextCompletionIndex = ThreadSafeDictionary<String, Int>()
 
     /// Date of the last generic identity reset request event, for more info see `shouldIgnoreStorePayload`
     private var lastResetDate = Atomic<Date>(Date(timeIntervalSince1970: 0))
@@ -67,6 +82,8 @@ class NetworkResponseHandler {
     func removeWaitingEvents(requestId: String) -> [Event]? {
         guard !requestId.isEmpty else { return nil }
 
+        highestObservedIndex.removeValue(forKey: requestId)
+        nextCompletionIndex.removeValue(forKey: requestId)
         return sentEventsWaitingResponse.removeValue(forKey: requestId)
     }
 
@@ -104,6 +121,15 @@ class NetworkResponseHandler {
                                 ignoreStorePayloads: ignoreStorePayloads)
             dispatchEventErrors(errorsArray: edgeResponse.errors, requestId: requestId)
             dispatchEventWarnings(warningsArray: edgeResponse.warnings, requestId: requestId)
+
+            // Early per-event completion: now that this fragment's handles/errors/warnings are all
+            // processed and accumulated, complete every waiting event whose index is strictly below the
+            // highest index observed so far — observing index M means events 0..M-1 have no more data
+            // coming. The highest index (and anything still pending) completes at stream close in
+            // `processResponseOnComplete`.
+            if NetworkResponseHandler.earlyPerEventCompletionEnabled {
+                sweepCompletions(requestId: requestId, exclusiveUpperBound: highestObservedIndexFor(requestId: requestId))
+            }
         } else {
             Log.warning(label: LOG_TAG,
                         "processResponseOnSuccess - The conversion to JSON failed for server response: \(jsonResponse), request id \(requestId)")
@@ -135,25 +161,104 @@ class NetworkResponseHandler {
     /// Processes the "on complete" response from the network layer by:
     /// 1. Unregistering request callbacks for each event and
     /// 2. Dispatching completion events for events that have specifically requested one.
+    ///
+    /// Events already completed early (see `sweepCompletions`) are not completed again here — only
+    /// the highest-indexed event and anything still pending complete at stream close.
     /// - Parameter requestId: The network request ID used to fetch the associated request events.
     func processResponseOnComplete(requestId: String) {
+        // Capture progress BEFORE removeWaitingEvents clears it.
+        let alreadyCompleted = NetworkResponseHandler.earlyPerEventCompletionEnabled ? completedCountFor(requestId: requestId) : 0
+
         guard let removedWaitingEvents = removeWaitingEvents(requestId: requestId) else { return }
 
-        for event in removedWaitingEvents {
-            // Unregister currently known completion handlers
-            CompletionHandlersManager.shared.unregisterCompletionHandler(forRequestEventId: event.id.uuidString)
+        guard alreadyCompleted < removedWaitingEvents.count else { return }
 
-            if sendCompletionRequested(event: event) {
-                let eventData = addEventAndRequestIdToDictionary([:], requestId: requestId, requestEventId: nil)
+        for index in alreadyCompleted..<removedWaitingEvents.count {
+            completeEvent(requestId: requestId, event: removedWaitingEvents[index])
+        }
+    }
 
-                let responseEvent = event.createResponseEvent(
-                    name: EdgeConstants.EventName.CONTENT_COMPLETE,
-                    type: EventType.edge,
-                    source: EventSource.contentComplete,
-                    data: eventData
-                )
-                MobileCore.dispatch(event: responseEvent)
+    /// - Returns: the number of leading events already early-completed for `requestId` (0 if none).
+    private func completedCountFor(requestId: String) -> Int {
+        return serialQueue.sync {
+            self.nextCompletionIndex[requestId] ?? 0
+        }
+    }
+
+    /// Completes a single waiting `event`: unregisters its completion handler and, if the event
+    /// requested it via `request.sendCompletion`, dispatches its `CONTENT_COMPLETE` response event.
+    /// This is the per-event completion action, called either early (index-advance) or at stream close.
+    private func completeEvent(requestId: String, event: Event) {
+        CompletionHandlersManager.shared.unregisterCompletionHandler(forRequestEventId: event.id.uuidString)
+
+        if sendCompletionRequested(event: event) {
+            let eventData = addEventAndRequestIdToDictionary([:], requestId: requestId, requestEventId: nil)
+
+            let responseEvent = event.createResponseEvent(
+                name: EdgeConstants.EventName.CONTENT_COMPLETE,
+                type: EventType.edge,
+                source: EventSource.contentComplete,
+                data: eventData
+            )
+            MobileCore.dispatch(event: responseEvent)
+        }
+    }
+
+    /// Records the highest indexed `eventIndex` observed so far for `requestId`, used to drive early
+    /// per-event completion. No-op when early completion is disabled or `index` is nil (global handles
+    /// / no-index broadcast errors — those must never advance completion).
+    ///
+    /// If an index arrives that is lower than the completion boundary already reached, that violates
+    /// the assumed grouping (data for an event that was already completed); it is logged at WARNING for
+    /// investigation and otherwise ignored (the boundary is never moved backwards, so no event is
+    /// completed twice).
+    private func recordObservedIndex(requestId: String, index: Int?) {
+        guard NetworkResponseHandler.earlyPerEventCompletionEnabled, let index = index, index >= 0 else { return }
+
+        serialQueue.sync {
+            if let completed = self.nextCompletionIndex[requestId], index < completed {
+                Log.warning(label: self.LOG_TAG,
+                            "Unexpected response ordering: eventIndex \(index) arrived for request id (\(requestId)) " +
+                            "after events through index \(completed - 1) were already completed. Not re-completing; " +
+                            "investigate response grouping/ordering.")
+                return
             }
+
+            let current = self.highestObservedIndex[requestId] ?? -1
+            if index > current {
+                self.highestObservedIndex[requestId] = index
+            }
+        }
+    }
+
+    /// - Returns: the highest indexed `eventIndex` observed so far for `requestId`, or -1 if none observed.
+    private func highestObservedIndexFor(requestId: String) -> Int {
+        return serialQueue.sync {
+            self.highestObservedIndex[requestId] ?? -1
+        }
+    }
+
+    /// Completes every waiting event for `requestId` whose position is at or after the current
+    /// completion boundary and strictly below `exclusiveUpperBound`, advancing the boundary so each
+    /// event completes exactly once.
+    /// - Parameters:
+    ///   - requestId: the batch request id
+    ///   - exclusiveUpperBound: complete events with index in `[nextCompletionIndex, min(exclusiveUpperBound, count))`
+    private func sweepCompletions(requestId: String, exclusiveUpperBound: Int) {
+        var toComplete: [Event] = []
+        serialQueue.sync {
+            guard let events = self.sentEventsWaitingResponse[requestId] else { return }
+            var next = self.nextCompletionIndex[requestId] ?? 0
+            let limit = min(exclusiveUpperBound, events.count)
+            while next < limit {
+                toComplete.append(events[next])
+                next += 1
+            }
+            self.nextCompletionIndex[requestId] = next
+        }
+
+        for event in toComplete {
+            completeEvent(requestId: requestId, event: event)
         }
     }
 
@@ -191,6 +296,18 @@ class NetworkResponseHandler {
                         handleLocationHintHandle(handle: eventHandle)
                     }
                 }
+            }
+
+            // Track the highest per-event index seen, to drive early per-event completion. Handles
+            // with no eventIndex (global handles) do not advance completion.
+            recordObservedIndex(requestId: requestId, index: eventHandle.eventIndex)
+
+            // Complete any lower-indexed events still pending BEFORE dispatching this handle's data.
+            // Observing this handle's index means every lower index has no more data coming, so their
+            // completions must fire before this handle is dispatched — not after, which would let this
+            // handle's data land ahead of a still-pending sibling's completion.
+            if NetworkResponseHandler.earlyPerEventCompletionEnabled, let eventIndex = eventHandle.eventIndex {
+                sweepCompletions(requestId: requestId, exclusiveUpperBound: eventIndex)
             }
 
             guard let eventHandleAsDictionary = eventHandle.asDictionary() else { continue }
@@ -253,7 +370,15 @@ class NetworkResponseHandler {
             if let errorAsDictionary = error.asDictionary() {
                 logErrorMessage(errorAsDictionary, isError: true, requestId: requestId)
 
-                let requestEvent = extractRequestEvent(forEventIndex: error.report?.eventIndex, requestId: requestId)
+                let eventIndex = error.report?.eventIndex
+                let requestEvent = extractRequestEvent(forEventIndex: eventIndex, requestId: requestId)
+
+                // Same ordering guarantee as processEventHandles, applied to the error channel.
+                recordObservedIndex(requestId: requestId, index: eventIndex)
+                if NetworkResponseHandler.earlyPerEventCompletionEnabled, let eventIndex = eventIndex {
+                    sweepCompletions(requestId: requestId, exclusiveUpperBound: eventIndex)
+                }
+
                 // set eventRequestId and Edge requestId on the response event and dispatch data
                 let eventData = addEventAndRequestIdToDictionary(errorAsDictionary,
                                                                  requestId: requestId,
@@ -282,7 +407,15 @@ class NetworkResponseHandler {
             if let warningsAsDictionary = warning.asDictionary() {
                 logErrorMessage(warningsAsDictionary, isError: false, requestId: requestId)
 
-                let requestEvent = extractRequestEvent(forEventIndex: warning.report?.eventIndex, requestId: requestId)
+                let eventIndex = warning.report?.eventIndex
+                let requestEvent = extractRequestEvent(forEventIndex: eventIndex, requestId: requestId)
+
+                // Same ordering guarantee as processEventHandles, applied to the warning channel.
+                recordObservedIndex(requestId: requestId, index: eventIndex)
+                if NetworkResponseHandler.earlyPerEventCompletionEnabled, let eventIndex = eventIndex {
+                    sweepCompletions(requestId: requestId, exclusiveUpperBound: eventIndex)
+                }
+
                 // set eventRequestId and Edge requestId on the response event and dispatch data
                 let eventData = addEventAndRequestIdToDictionary(warningsAsDictionary,
                                                                  requestId: requestId,

--- a/Sources/EdgeNetworkHandlers/NetworkResponseHandler.swift
+++ b/Sources/EdgeNetworkHandlers/NetworkResponseHandler.swift
@@ -285,7 +285,7 @@ class NetworkResponseHandler {
         Log.trace(label: LOG_TAG, "processEventHandles - Processing \(unwrappedEventHandles.count) event handle(s) for request id: \(requestId)")
 
         for eventHandle in unwrappedEventHandles {
-            let requestEvent = extractRequestEvent(forEventIndex: eventHandle.eventIndex, requestId: requestId)
+            let requestEvent = resolveHandleRequestEvent(eventIndex: eventHandle.eventIndex, handleType: eventHandle.type, requestId: requestId)
             if ignoreStorePayloads {
                 Log.debug(label: LOG_TAG, "Identities were reset recently, ignoring state:store payload for request with id: \(requestId)")
             } else {
@@ -319,23 +319,77 @@ class NetworkResponseHandler {
         }
     }
 
-    /// Extracts the request event paired with this event handle/error handle based on the index. If no match is found or the event handle index is missing, this method returns nil.
+    /// Extracts the request event paired with this event handle/error handle based on the index. If no match is found, this method returns nil.
     ///
     /// - Parameters:
     ///   - forEventIndex: the `EdgeEventHandle`/ `EdgeEventError` event index
     ///   - requestId: edge request id used to fetch the waiting events associated with it (if any)
     /// - Returns: the request event for which this event handle was received, nil if not found
-    private func extractRequestEvent(forEventIndex: Int?, requestId: String) -> Event? {
+    private func extractRequestEvent(forEventIndex eventIndex: Int, requestId: String) -> Event? {
         guard let requestEventList = getWaitingEvents(requestId: requestId) else { return nil }
+        guard eventIndex >= 0, eventIndex < requestEventList.count else { return nil }
+        return requestEventList[eventIndex]
+    }
 
-        // Note: ExEdge does not return eventIndex when there is only one event in the request.
-        // The event handles and errors are associated to that request event, so defaulting to 0 here.
-        let index = forEventIndex ?? 0
-        guard index >= 0, index < requestEventList.count else {
-            return nil
+    /// Determines whether `handleType` is a session/batch-scoped handle type that carries no `eventIndex`
+    /// by design (`state:store`, `locationHint:result`) — these apply to the whole request rather than a
+    /// specific event, so they are broadcast rather than attributed to one event.
+    private func isGlobalHandleType(_ handleType: String?) -> Bool {
+        guard let handleType = handleType else { return false }
+        return handleType == EdgeConstants.JsonKeys.Response.EventHandleType.STORE
+            || handleType == EdgeConstants.JsonKeys.Response.EventHandleType.LOCATION_HINT
+    }
+
+    /// Resolves the request event a handle should be attributed to. Mirrors `aepsdk-edge-android`'s
+    /// routing policy for the handle channel — needed because batching means a response can now have
+    /// more than one waiting event, so a missing `eventIndex` is no longer unambiguous:
+    /// - `eventIndex` present -> the specific event at that position (`extractRequestEvent`).
+    /// - `eventIndex` absent, exactly one waiting event -> unambiguous; route to it (ExEdge omits
+    ///   `eventIndex` when the request has a single event).
+    /// - `eventIndex` absent, multiple waiting events, a global handle type (`state:store`,
+    ///   `locationHint:result`) -> broadcast: nil parent. The side effect (store payload / location hint
+    ///   update) is still applied globally regardless of attribution.
+    /// - `eventIndex` absent, multiple waiting events, any other handle type -> unexpected; nil parent,
+    ///   logged as a warning so it can be investigated.
+    private func resolveHandleRequestEvent(eventIndex: Int?, handleType: String?, requestId: String) -> Event? {
+        if let eventIndex = eventIndex {
+            return extractRequestEvent(forEventIndex: eventIndex, requestId: requestId)
         }
 
-        return requestEventList[index]
+        guard let waitingEvents = getWaitingEvents(requestId: requestId), !waitingEvents.isEmpty else { return nil }
+        if waitingEvents.count == 1 {
+            return waitingEvents.first ?? nil
+        }
+
+        if isGlobalHandleType(handleType) {
+            Log.trace(label: LOG_TAG, "Handle type '\(handleType ?? "unknown")' is a global handle (no eventIndex) - broadcasting with nil parent (requestId: \(requestId))")
+        } else {
+            Log.warning(label: LOG_TAG,
+                        "Handle type '\(handleType ?? "unknown")' has no eventIndex in a batch of \(waitingEvents.count) events " +
+                        "and is not a known global type - skipping per-event attribution (requestId: \(requestId))")
+        }
+        return nil
+    }
+
+    /// Resolves the request event(s) an error/warning should be attributed to. Mirrors
+    /// `aepsdk-edge-android`'s routing policy for the error/warning channel:
+    /// - `eventIndex` present -> a single-element result routed via `extractRequestEvent`.
+    /// - `eventIndex` absent, no waiting events registered -> a single `nil` (broadcast), preserving
+    ///   behavior for callers that never registered waiting events.
+    /// - `eventIndex` absent, one or more waiting events -> fan out: one dispatch per waiting event. A
+    ///   single waiting event naturally yields that one event (pre-batching contract unchanged); a
+    ///   root-level error/warning on a batch of N>1 is delivered to every event, since any of them could
+    ///   be the one it actually applies to.
+    private func resolveErrorRequestEvents(eventIndex: Int?, requestId: String) -> [Event?] {
+        if let eventIndex = eventIndex {
+            return [extractRequestEvent(forEventIndex: eventIndex, requestId: requestId)]
+        }
+
+        guard let waitingEvents = getWaitingEvents(requestId: requestId), !waitingEvents.isEmpty else {
+            return [nil]
+        }
+
+        return waitingEvents
     }
 
     /// Dispatches a response event with the provided event handle as `[String: Any]`, including the request event id and request identifier
@@ -371,7 +425,6 @@ class NetworkResponseHandler {
                 logErrorMessage(errorAsDictionary, isError: true, requestId: requestId)
 
                 let eventIndex = error.report?.eventIndex
-                let requestEvent = extractRequestEvent(forEventIndex: eventIndex, requestId: requestId)
 
                 // Same ordering guarantee as processEventHandles, applied to the error channel.
                 recordObservedIndex(requestId: requestId, index: eventIndex)
@@ -379,12 +432,16 @@ class NetworkResponseHandler {
                     sweepCompletions(requestId: requestId, exclusiveUpperBound: eventIndex)
                 }
 
-                // set eventRequestId and Edge requestId on the response event and dispatch data
-                let eventData = addEventAndRequestIdToDictionary(errorAsDictionary,
-                                                                 requestId: requestId,
-                                                                 requestEventId: requestEvent?.id.uuidString)
-                guard !eventData.isEmpty else { continue }
-                dispatchResponseEventWithData(eventData, parentRequestEvent: requestEvent, isErrorResponseEvent: true, eventSource: nil)
+                // A root-level (no-index) error on a batch of N>1 events is fanned out to every waiting
+                // event, since any of them could be the one that actually failed.
+                for requestEvent in resolveErrorRequestEvents(eventIndex: eventIndex, requestId: requestId) {
+                    // set eventRequestId and Edge requestId on the response event and dispatch data
+                    let eventData = addEventAndRequestIdToDictionary(errorAsDictionary,
+                                                                     requestId: requestId,
+                                                                     requestEventId: requestEvent?.id.uuidString)
+                    guard !eventData.isEmpty else { continue }
+                    dispatchResponseEventWithData(eventData, parentRequestEvent: requestEvent, isErrorResponseEvent: true, eventSource: nil)
+                }
             }
         }
     }
@@ -408,7 +465,6 @@ class NetworkResponseHandler {
                 logErrorMessage(warningsAsDictionary, isError: false, requestId: requestId)
 
                 let eventIndex = warning.report?.eventIndex
-                let requestEvent = extractRequestEvent(forEventIndex: eventIndex, requestId: requestId)
 
                 // Same ordering guarantee as processEventHandles, applied to the warning channel.
                 recordObservedIndex(requestId: requestId, index: eventIndex)
@@ -416,12 +472,16 @@ class NetworkResponseHandler {
                     sweepCompletions(requestId: requestId, exclusiveUpperBound: eventIndex)
                 }
 
-                // set eventRequestId and Edge requestId on the response event and dispatch data
-                let eventData = addEventAndRequestIdToDictionary(warningsAsDictionary,
-                                                                 requestId: requestId,
-                                                                 requestEventId: requestEvent?.id.uuidString)
-                guard !eventData.isEmpty else { return }
-                dispatchResponseEventWithData(eventData, parentRequestEvent: requestEvent, isErrorResponseEvent: true, eventSource: nil)
+                // A root-level (no-index) warning on a batch of N>1 events is fanned out to every
+                // waiting event, since any of them could be the one it actually applies to.
+                for requestEvent in resolveErrorRequestEvents(eventIndex: eventIndex, requestId: requestId) {
+                    // set eventRequestId and Edge requestId on the response event and dispatch data
+                    let eventData = addEventAndRequestIdToDictionary(warningsAsDictionary,
+                                                                     requestId: requestId,
+                                                                     requestEventId: requestEvent?.id.uuidString)
+                    guard !eventData.isEmpty else { continue }
+                    dispatchResponseEventWithData(eventData, parentRequestEvent: requestEvent, isErrorResponseEvent: true, eventSource: nil)
+                }
             }
         }
     }

--- a/Sources/EdgeNetworkHandlers/SharedStateReader.swift
+++ b/Sources/EdgeNetworkHandlers/SharedStateReader.swift
@@ -39,15 +39,36 @@ struct SharedStateReader {
         return edgeConfig ?? [:]
     }
 
-    /// Reads the `edge.batching.enabled` flag from the Configuration shared state for the given `event`.
+    /// Reads the `edge.batching.enabled` and `edge.batching.eventNameAllowlist` keys for the given `event`,
+    /// mirroring `aepsdk-edge-android`'s `EventUtils.getEdgeConfiguration` batching section.
+    ///
+    /// This is a per-key fallback, not a wholesale configuration replacement: the bundled config
+    /// (`EdgeBundledBatchingConfig`) is only consulted for a given key when that key is absent from the
+    /// Configuration shared state. Any value present in the Configuration shared state - whether set
+    /// programmatically or delivered by a remote/Launch-published configuration - always wins over the
+    /// bundled file's value for that same key.
     /// - Parameter event: the `Event` used to retrieve the Configuration shared state.
-    /// - Returns: true if batching is enabled in Configuration, false if unset or the shared state is unavailable.
-    func isBatchingEnabled(event: Event) -> Bool {
-        guard let configurationState = getSharedState(EdgeConstants.SharedState.Configuration.STATE_OWNER_NAME, event, false)?.value else {
-            return false
+    /// - Returns: a dictionary containing whichever of the two batching keys resolved to a value, from
+    ///   Configuration shared state or the bundled fallback.
+    func getEdgeBatchingConfig(event: Event) -> [String: Any] {
+        let configurationState = getSharedState(EdgeConstants.SharedState.Configuration.STATE_OWNER_NAME, event, false)?.value ?? [:]
+        let bundledBatchingConfig = EdgeBundledBatchingConfig.get()
+
+        var batchingConfig: [String: Any] = [:]
+
+        if let enabled = configurationState[EdgeConstants.SharedState.Configuration.EDGE_BATCHING_ENABLED] {
+            batchingConfig[EdgeConstants.SharedState.Configuration.EDGE_BATCHING_ENABLED] = enabled as? Bool ?? false
+        } else if let bundledEnabled = bundledBatchingConfig[EdgeConstants.SharedState.Configuration.EDGE_BATCHING_ENABLED] {
+            batchingConfig[EdgeConstants.SharedState.Configuration.EDGE_BATCHING_ENABLED] = bundledEnabled as? Bool ?? false
         }
 
-        return configurationState[EdgeConstants.SharedState.Configuration.EDGE_BATCHING_ENABLED] as? Bool ?? false
+        if let allowlist = configurationState[EdgeConstants.SharedState.Configuration.EDGE_BATCHING_EVENT_NAME_ALLOWLIST] {
+            batchingConfig[EdgeConstants.SharedState.Configuration.EDGE_BATCHING_EVENT_NAME_ALLOWLIST] = allowlist as? [String]
+        } else if let bundledAllowlist = bundledBatchingConfig[EdgeConstants.SharedState.Configuration.EDGE_BATCHING_EVENT_NAME_ALLOWLIST] {
+            batchingConfig[EdgeConstants.SharedState.Configuration.EDGE_BATCHING_EVENT_NAME_ALLOWLIST] = bundledAllowlist as? [String]
+        }
+
+        return batchingConfig
     }
 
     /// Get the Assurance integration ID from the Assurance shared state for the given `event`.

--- a/Sources/EdgeNetworkHandlers/SharedStateReader.swift
+++ b/Sources/EdgeNetworkHandlers/SharedStateReader.swift
@@ -39,6 +39,17 @@ struct SharedStateReader {
         return edgeConfig ?? [:]
     }
 
+    /// Reads the `edge.batching.enabled` flag from the Configuration shared state for the given `event`.
+    /// - Parameter event: the `Event` used to retrieve the Configuration shared state.
+    /// - Returns: true if batching is enabled in Configuration, false if unset or the shared state is unavailable.
+    func isBatchingEnabled(event: Event) -> Bool {
+        guard let configurationState = getSharedState(EdgeConstants.SharedState.Configuration.STATE_OWNER_NAME, event, false)?.value else {
+            return false
+        }
+
+        return configurationState[EdgeConstants.SharedState.Configuration.EDGE_BATCHING_ENABLED] as? Bool ?? false
+    }
+
     /// Get the Assurance integration ID from the Assurance shared state for the given `event`.
     /// - Parameter event: the `Event` used to retrieve the Assurance shared state.
     /// - Returns: the `integrationid` from the Assurance shared state or nil if the shared state or integration id is does not exist.

--- a/Sources/EdgeNetworkHandlers/SharedStateReader.swift
+++ b/Sources/EdgeNetworkHandlers/SharedStateReader.swift
@@ -39,8 +39,9 @@ struct SharedStateReader {
         return edgeConfig ?? [:]
     }
 
-    /// Reads the `edge.batching.enabled` and `edge.batching.eventNameAllowlist` keys for the given `event`,
-    /// mirroring `aepsdk-edge-android`'s `EventUtils.getEdgeConfiguration` batching section.
+    /// Reads the `edge.batching.enabled`, `edge.batching.eventNameAllowlist`, and `edge.batching.maxBatchSize`
+    /// keys for the given `event`, mirroring `aepsdk-edge-android`'s `EventUtils.getEdgeConfiguration`
+    /// batching section.
     ///
     /// This is a per-key fallback, not a wholesale configuration replacement: the bundled config
     /// (`EdgeBundledBatchingConfig`) is only consulted for a given key when that key is absent from the
@@ -48,8 +49,10 @@ struct SharedStateReader {
     /// programmatically or delivered by a remote/Launch-published configuration - always wins over the
     /// bundled file's value for that same key.
     /// - Parameter event: the `Event` used to retrieve the Configuration shared state.
-    /// - Returns: a dictionary containing whichever of the two batching keys resolved to a value, from
-    ///   Configuration shared state or the bundled fallback.
+    /// - Returns: a dictionary containing whichever of the three batching keys resolved to a value, from
+    ///   Configuration shared state or the bundled fallback. `edge.batching.maxBatchSize` is left absent
+    ///   when not present/castable as an `Int`; defaulting and clamping to the allowed range is applied
+    ///   later by `EdgeBatchingHitQueue` at batch-size computation time.
     func getEdgeBatchingConfig(event: Event) -> [String: Any] {
         let configurationState = getSharedState(EdgeConstants.SharedState.Configuration.STATE_OWNER_NAME, event, false)?.value ?? [:]
         let bundledBatchingConfig = EdgeBundledBatchingConfig.get()
@@ -66,6 +69,12 @@ struct SharedStateReader {
             batchingConfig[EdgeConstants.SharedState.Configuration.EDGE_BATCHING_EVENT_NAME_ALLOWLIST] = allowlist as? [String]
         } else if let bundledAllowlist = bundledBatchingConfig[EdgeConstants.SharedState.Configuration.EDGE_BATCHING_EVENT_NAME_ALLOWLIST] {
             batchingConfig[EdgeConstants.SharedState.Configuration.EDGE_BATCHING_EVENT_NAME_ALLOWLIST] = bundledAllowlist as? [String]
+        }
+
+        if let maxBatchSize = configurationState[EdgeConstants.SharedState.Configuration.EDGE_BATCHING_MAX_BATCH_SIZE] {
+            batchingConfig[EdgeConstants.SharedState.Configuration.EDGE_BATCHING_MAX_BATCH_SIZE] = maxBatchSize as? Int
+        } else if let bundledMaxBatchSize = bundledBatchingConfig[EdgeConstants.SharedState.Configuration.EDGE_BATCHING_MAX_BATCH_SIZE] {
+            batchingConfig[EdgeConstants.SharedState.Configuration.EDGE_BATCHING_MAX_BATCH_SIZE] = bundledMaxBatchSize as? Int
         }
 
         return batchingConfig

--- a/TestApps/TestAppSwiftUI/adb_edgeBatchingConfig.json
+++ b/TestApps/TestAppSwiftUI/adb_edgeBatchingConfig.json
@@ -1,0 +1,15 @@
+{
+  "edge.batching.enabled": true,
+  "edge.batching.eventNameAllowlist": [
+    "Edge Optimize Personalization Request",
+    "Retrieve message definitions",
+    "Messaging interaction event",
+    "Push tracking edge event",
+    "Push notification token profile Edge event",
+    "MediaEdge event - media.sessionStart",
+    "MediaEdge event - media.play",
+    "MediaEdge event - media.sessionComplete",
+    "AEP Request Event"
+  ],
+  "edge.batching.maxBatchSize": 10
+}

--- a/Tests/FunctionalTests/AEPEdgeFunctionalTests.swift
+++ b/Tests/FunctionalTests/AEPEdgeFunctionalTests.swift
@@ -935,7 +935,7 @@ class AEPEdgeFunctionalTests: TestBase, AnyCodableAsserts {
     // MARK: test persisted hits
 
     func testSendEvent_withXDMData_sendsExEdgeNetworkRequest_afterPersisting() {
-        let error = EdgeEventError(title: nil, detail: "X service is temporarily unable to serve this request. Please try again later.", status: 503, type: "test-type", report: nil)
+        let error = EdgeResponseError(title: nil, detail: "X service is temporarily unable to serve this request. Please try again later.", status: 503, type: "test-type", report: nil)
         let edgeResponse = EdgeResponse(requestId: "test-req-id", handle: nil, errors: [error], warnings: nil)
         let responseData = try? JSONEncoder().encode(edgeResponse)
 
@@ -976,7 +976,7 @@ class AEPEdgeFunctionalTests: TestBase, AnyCodableAsserts {
     }
 
     func testSendEvent_withXDMData_sendsExEdgeNetworkRequest_afterPersistingMultipleHits() {
-        let error = EdgeEventError(title: nil, detail: "X service is temporarily unable to serve this request. Please try again later.", status: 503, type: nil, report: nil)
+        let error = EdgeResponseError(title: nil, detail: "X service is temporarily unable to serve this request. Please try again later.", status: 503, type: nil, report: nil)
         let edgeResponse = EdgeResponse(requestId: "test-req-id", handle: nil, errors: [error], warnings: nil)
         let responseData = try? JSONEncoder().encode(edgeResponse)
 
@@ -1131,10 +1131,10 @@ class AEPEdgeFunctionalTests: TestBase, AnyCodableAsserts {
         }
 
         let jsonData = try! JSONSerialization.data(withJSONObject: eventDataDict)
-        let expectedEdgeEventError = try? JSONDecoder().decode(EdgeEventError.self, from: response.data(using: .utf8)!)
-        let edgeEventError = try? JSONDecoder().decode(EdgeEventError.self, from: jsonData)
+        let expectedEdgeResponseError = try? JSONDecoder().decode(EdgeResponseError.self, from: response.data(using: .utf8)!)
+        let edgeResponseError = try? JSONDecoder().decode(EdgeResponseError.self, from: jsonData)
 
-        XCTAssertEqual(expectedEdgeEventError, edgeEventError)
+        XCTAssertEqual(expectedEdgeResponseError, edgeResponseError)
     }
 
     func testSendEvent_fatalError400() {
@@ -1175,10 +1175,10 @@ class AEPEdgeFunctionalTests: TestBase, AnyCodableAsserts {
         }
 
         let jsonData = try! JSONSerialization.data(withJSONObject: eventDataDict)
-        let expectedEdgeEventError = try? JSONDecoder().decode(EdgeEventError.self, from: response.data(using: .utf8)!)
-        let edgeEventError = try? JSONDecoder().decode(EdgeEventError.self, from: jsonData)
+        let expectedEdgeResponseError = try? JSONDecoder().decode(EdgeResponseError.self, from: response.data(using: .utf8)!)
+        let edgeResponseError = try? JSONDecoder().decode(EdgeResponseError.self, from: jsonData)
 
-        XCTAssertEqual(expectedEdgeEventError, edgeEventError)
+        XCTAssertEqual(expectedEdgeResponseError, edgeResponseError)
     }
 
     func testSendEvent_recoverableNetworkTransportError_retries() {
@@ -1249,10 +1249,10 @@ class AEPEdgeFunctionalTests: TestBase, AnyCodableAsserts {
         }
 
         let jsonData = try! JSONSerialization.data(withJSONObject: eventDataDict)
-        let expectedEdgeEventError = try? JSONDecoder().decode(EdgeEventError.self, from: response.data(using: .utf8)!)
-        let edgeEventError = try? JSONDecoder().decode(EdgeEventError.self, from: jsonData)
+        let expectedEdgeResponseError = try? JSONDecoder().decode(EdgeResponseError.self, from: response.data(using: .utf8)!)
+        let edgeResponseError = try? JSONDecoder().decode(EdgeResponseError.self, from: jsonData)
 
-        XCTAssertEqual(expectedEdgeEventError, edgeEventError)
+        XCTAssertEqual(expectedEdgeResponseError, edgeResponseError)
     }
 
     // MARK: Test Send Event with Configurable Endpoint
@@ -1441,7 +1441,7 @@ class AEPEdgeFunctionalTests: TestBase, AnyCodableAsserts {
         XCTAssertTrue(resultNetworkRequests[1].url.absoluteURL.absoluteString.hasPrefix(TestConstants.EX_EDGE_INTERACT_PROD_URL_STR))
     }
 
-    func getEdgeEventError(message: String, code: String) -> EdgeEventError {
+    func getEdgeResponseError(message: String, code: String) -> EdgeResponseError {
         let data = """
              {
                 "message": "\(message)",
@@ -1449,10 +1449,10 @@ class AEPEdgeFunctionalTests: TestBase, AnyCodableAsserts {
              }
          """.data(using: .utf8)
         let decoder = JSONDecoder()
-        return try! decoder.decode(EdgeEventError.self, from: data!) // swiftlint:disable:this force_unwrapping
+        return try! decoder.decode(EdgeResponseError.self, from: data!) // swiftlint:disable:this force_unwrapping
     }
 
-    func getEdgeEventError(message: String, code: String, namespace: String, index: Int) -> EdgeEventError {
+    func getEdgeResponseError(message: String, code: String, namespace: String, index: Int) -> EdgeResponseError {
         let data = """
              {
                 "message": "\(message)",
@@ -1462,7 +1462,7 @@ class AEPEdgeFunctionalTests: TestBase, AnyCodableAsserts {
              }
          """.data(using: .utf8)
         let decoder = JSONDecoder()
-        return try! decoder.decode(EdgeEventError.self, from: data!) // swiftlint:disable:this force_unwrapping
+        return try! decoder.decode(EdgeResponseError.self, from: data!) // swiftlint:disable:this force_unwrapping
     }
 
     /// Generates a JSON string representing a network request payload. It

--- a/Tests/FunctionalTests/EdgeQueuedEntityFunctionalTests.swift
+++ b/Tests/FunctionalTests/EdgeQueuedEntityFunctionalTests.swift
@@ -139,14 +139,57 @@ class EdgeQueuedEntityFunctionalTests: TestBase, AnyCodableAsserts {
         assertExpectedEvents(ignoreUnexpectedEvents: true, timeout: TIMEOUT_SEC)
     }
 
+    // Tests that several ExperienceEvents already queued (snapshotted with batching enabled) before
+    // Edge starts processing are coalesced into a single network request, instead of one request per
+    // event, once the hit queue begins draining them.
+    func testQueuedDataEntities_withBatchingEnabled_areSentAsOneNetworkRequest() {
+        guard let dataQueue = getDataQueue() else {
+            XCTFail("Failed to get DataQueue.")
+            return
+        }
+
+        // `configuration` mirrors production's `SharedStateReader.getEdgeConfig` output, which is
+        // always a pure [String: String]-compatible dict (configId/environment/domain only) —
+        // `batchingEnabled` is snapshotted as its own separate top-level field, never inside `configuration`.
+        let edgeConfig: [String: AnyCodable] = ["edge.configId": AnyCodable("12345-example")]
+        mockQueuedEvent(dataQueue: dataQueue, edgeConfig: edgeConfig, entityId: "entity-uuid-1", batchingEnabled: true)
+        mockQueuedEvent(dataQueue: dataQueue, edgeConfig: edgeConfig, entityId: "entity-uuid-2", batchingEnabled: true)
+        mockQueuedEvent(dataQueue: dataQueue, edgeConfig: edgeConfig, entityId: "entity-uuid-3", batchingEnabled: true)
+
+        let responseConnection: HttpConnection = HttpConnection(data: "{\"test\": \"json\"}".data(using: .utf8),
+                                                                response: HTTPURLResponse(url: exEdgeInteractProdUrl,
+                                                                                          statusCode: 200,
+                                                                                          httpVersion: nil,
+                                                                                          headerFields: nil),
+                                                                error: nil)
+        mockNetworkService.setMockResponse(url: TestConstants.EX_EDGE_INTERACT_PROD_URL_STR, httpMethod: HttpMethod.post, responseConnection: responseConnection)
+        mockNetworkService.setExpectationForNetworkRequest(url: TestConstants.EX_EDGE_INTERACT_PROD_URL_STR, httpMethod: HttpMethod.post, expectedCount: 1)
+
+        startMobileSDK()
+
+        mockNetworkService.assertAllNetworkRequestExpectations(timeout: TIMEOUT_SEC)
+        let resultNetworkRequests = mockNetworkService.getNetworkRequestsWith(url: TestConstants.EX_EDGE_INTERACT_PROD_URL_STR, httpMethod: HttpMethod.post, timeout: TIMEOUT_SEC)
+
+        // Exactly one request for all 3 queued events.
+        XCTAssertEqual(1, resultNetworkRequests.count)
+
+        guard let payloadJson = try? JSONSerialization.jsonObject(with: resultNetworkRequests[0].connectPayload) as? [String: Any],
+              let events = payloadJson["events"] as? [[String: Any]] else {
+            XCTFail("Failed to parse the batch request payload's events array.")
+            return
+        }
+        XCTAssertEqual(3, events.count)
+    }
+
     /// Add a `DataEntity` into the given `DataQueue`.
     /// - Parameters:
     ///   - dataQueue: the `DataQueue` to add the new entity
     ///   - edgeConfig: the Edge configuration to include with the `EdgeDataEntity`
     ///   - entityId: the UUID to identify the `DataEntity`
-    private func mockQueuedEvent(dataQueue: DataQueue, edgeConfig: [String: AnyCodable], entityId: String = "entity-uuid") {
+    ///   - batchingEnabled: whether `edge.batching.enabled` was snapshotted as true when the hit was queued
+    private func mockQueuedEvent(dataQueue: DataQueue, edgeConfig: [String: AnyCodable], entityId: String = "entity-uuid", batchingEnabled: Bool = false) {
         let experienceEvent = Event(name: "queued event", type: EventType.edge, source: EventSource.requestContent, data: ["xdm": ["test": "data"]])
-        let edgeEntity = EdgeDataEntity(event: experienceEvent, configuration: edgeConfig, identityMap: [:])
+        let edgeEntity = EdgeDataEntity(event: experienceEvent, configuration: edgeConfig, identityMap: [:], batchingEnabled: batchingEnabled)
         let entity = DataEntity(uniqueIdentifier: entityId, timestamp: Date(), data: try? JSONEncoder().encode(edgeEntity))
 
         dataQueue.add(dataEntity: entity)

--- a/Tests/FunctionalTests/EdgeQueuedEntityFunctionalTests.swift
+++ b/Tests/FunctionalTests/EdgeQueuedEntityFunctionalTests.swift
@@ -148,13 +148,17 @@ class EdgeQueuedEntityFunctionalTests: TestBase, AnyCodableAsserts {
             return
         }
 
-        // `configuration` mirrors production's `SharedStateReader.getEdgeConfig` output, which is
-        // always a pure [String: String]-compatible dict (configId/environment/domain only) —
-        // `batchingEnabled` is snapshotted as its own separate top-level field, never inside `configuration`.
-        let edgeConfig: [String: AnyCodable] = ["edge.configId": AnyCodable("12345-example")]
-        mockQueuedEvent(dataQueue: dataQueue, edgeConfig: edgeConfig, entityId: "entity-uuid-1", batchingEnabled: true)
-        mockQueuedEvent(dataQueue: dataQueue, edgeConfig: edgeConfig, entityId: "entity-uuid-2", batchingEnabled: true)
-        mockQueuedEvent(dataQueue: dataQueue, edgeConfig: edgeConfig, entityId: "entity-uuid-3", batchingEnabled: true)
+        // `configuration` mirrors production's snapshotted Edge configuration, which now also carries
+        // the batching keys (`edge.batching.enabled`/`edge.batching.eventNameAllowlist`) alongside
+        // configId/environment/domain — batching requires both: enabled AND the event's name allowlisted.
+        let edgeConfig: [String: AnyCodable] = [
+            "edge.configId": AnyCodable("12345-example"),
+            EdgeConstants.SharedState.Configuration.EDGE_BATCHING_ENABLED: AnyCodable(true),
+            EdgeConstants.SharedState.Configuration.EDGE_BATCHING_EVENT_NAME_ALLOWLIST: AnyCodable(["queued event"])
+        ]
+        mockQueuedEvent(dataQueue: dataQueue, edgeConfig: edgeConfig, entityId: "entity-uuid-1")
+        mockQueuedEvent(dataQueue: dataQueue, edgeConfig: edgeConfig, entityId: "entity-uuid-2")
+        mockQueuedEvent(dataQueue: dataQueue, edgeConfig: edgeConfig, entityId: "entity-uuid-3")
 
         let responseConnection: HttpConnection = HttpConnection(data: "{\"test\": \"json\"}".data(using: .utf8),
                                                                 response: HTTPURLResponse(url: exEdgeInteractProdUrl,
@@ -186,10 +190,9 @@ class EdgeQueuedEntityFunctionalTests: TestBase, AnyCodableAsserts {
     ///   - dataQueue: the `DataQueue` to add the new entity
     ///   - edgeConfig: the Edge configuration to include with the `EdgeDataEntity`
     ///   - entityId: the UUID to identify the `DataEntity`
-    ///   - batchingEnabled: whether `edge.batching.enabled` was snapshotted as true when the hit was queued
-    private func mockQueuedEvent(dataQueue: DataQueue, edgeConfig: [String: AnyCodable], entityId: String = "entity-uuid", batchingEnabled: Bool = false) {
+    private func mockQueuedEvent(dataQueue: DataQueue, edgeConfig: [String: AnyCodable], entityId: String = "entity-uuid") {
         let experienceEvent = Event(name: "queued event", type: EventType.edge, source: EventSource.requestContent, data: ["xdm": ["test": "data"]])
-        let edgeEntity = EdgeDataEntity(event: experienceEvent, configuration: edgeConfig, identityMap: [:], batchingEnabled: batchingEnabled)
+        let edgeEntity = EdgeDataEntity(event: experienceEvent, configuration: edgeConfig, identityMap: [:])
         let entity = DataEntity(uniqueIdentifier: entityId, timestamp: Date(), data: try? JSONEncoder().encode(edgeEntity))
 
         dataQueue.add(dataEntity: entity)

--- a/Tests/FunctionalTests/NetworkResponseHandlerFunctionalTests.swift
+++ b/Tests/FunctionalTests/NetworkResponseHandlerFunctionalTests.swift
@@ -1610,4 +1610,115 @@ class NetworkResponseHandlerFunctionalTests: TestBase, AnyCodableAsserts {
             assertEqual(expected: expectedEventData, actual: completeEvent, file: file, line: line)
         }
     }
+
+    // MARK: Early per-event completion (index-advance)
+
+    /// A single streamed fragment carrying one indexed, non-global handle for `eventIndex`.
+    private func indexedHandleFragment(eventIndex: Int) -> String {
+        return """
+        {
+          "handle": [
+            { "type": "pairedeventexample", "eventIndex": \(eventIndex), "payload": [ { "id": "p\(eventIndex)" } ] }
+          ]
+        }
+        """
+    }
+
+    private func completionEvent(name: String) -> Event {
+        return Event(name: name, type: "testType", source: "testSource", data: requestSendCompletionTrueEventData)
+    }
+
+    func testEarlyCompletion_multiEventStream_completesEachEventWhenNextIndexArrives() {
+        let requestId = "req-early"
+        let e0 = completionEvent(name: "e0")
+        let e1 = completionEvent(name: "e1")
+        let e2 = completionEvent(name: "e2")
+        networkResponseHandler.addWaitingEvents(requestId: requestId, batchedEvents: [e0, e1, e2])
+
+        // index 0 fragment: nothing completes yet (no higher index seen)
+        networkResponseHandler.processResponseOnSuccess(jsonResponse: indexedHandleFragment(eventIndex: 0), requestId: requestId)
+        XCTAssertEqual(0, getDispatchedEventsWith(type: EventType.edge, source: TestConstants.EventSource.CONTENT_COMPLETE, timeout: 1).count)
+
+        // index 1 fragment: event 0 is now known complete
+        networkResponseHandler.processResponseOnSuccess(jsonResponse: indexedHandleFragment(eventIndex: 1), requestId: requestId)
+        var completes = getDispatchedEventsWith(type: EventType.edge, source: TestConstants.EventSource.CONTENT_COMPLETE)
+        XCTAssertEqual(1, completes.count)
+        XCTAssertEqual(e0.id, completes[0].parentID)
+
+        // index 2 fragment: event 1 now completes
+        networkResponseHandler.processResponseOnSuccess(jsonResponse: indexedHandleFragment(eventIndex: 2), requestId: requestId)
+        completes = getDispatchedEventsWith(type: EventType.edge, source: TestConstants.EventSource.CONTENT_COMPLETE)
+        XCTAssertEqual(2, completes.count)
+        XCTAssertEqual(e1.id, completes[1].parentID)
+
+        // stream close: the last event (index 2) completes
+        networkResponseHandler.processResponseOnComplete(requestId: requestId)
+        completes = getDispatchedEventsWith(type: EventType.edge, source: TestConstants.EventSource.CONTENT_COMPLETE)
+        XCTAssertEqual(3, completes.count)
+        XCTAssertEqual(e2.id, completes[2].parentID)
+    }
+
+    func testEarlyCompletion_completionFiresBeforeNextIndexHandleDispatch() {
+        // A completing event's downstream listeners (e.g. a caller merging accumulated response data
+        // into its own cache on completion) must never observe a higher-indexed sibling's handle data
+        // that arrived in the same response — so completion(0) must be dispatched strictly before
+        // index 1's own handle is dispatched, not after.
+        let requestId = "req-order"
+        let e0 = completionEvent(name: "e0")
+        let e1 = completionEvent(name: "e1")
+        networkResponseHandler.addWaitingEvents(requestId: requestId, batchedEvents: [e0, e1])
+
+        var dispatchOrder: [Event] = []
+        let orderQueue = DispatchQueue(label: "test.orderQueue")
+        MobileCore.registerEventListener(type: EventType.wildcard, source: EventSource.wildcard) { event in
+            orderQueue.sync { dispatchOrder.append(event) }
+        }
+
+        // index 0 fragment: wait for its handle to be fully dispatched, then clear the capture so
+        // only the second call's events (the ones under test) remain in `dispatchOrder`.
+        setExpectationEvent(type: TestConstants.EventType.EDGE, source: "pairedeventexample", expectedCount: 1)
+        networkResponseHandler.processResponseOnSuccess(jsonResponse: indexedHandleFragment(eventIndex: 0), requestId: requestId)
+        assertExpectedEvents(ignoreUnexpectedEvents: true)
+        resetTestExpectations()
+        orderQueue.sync { dispatchOrder.removeAll() }
+
+        // index 1 fragment, in this SAME processResponseOnSuccess call: this must first complete
+        // event 0, THEN dispatch index 1's own handle — not the other way around.
+        setExpectationEvent(type: TestConstants.EventType.EDGE, source: "pairedeventexample", expectedCount: 1)
+        setExpectationEvent(type: TestConstants.EventType.EDGE, source: TestConstants.EventSource.CONTENT_COMPLETE, expectedCount: 1)
+        networkResponseHandler.processResponseOnSuccess(jsonResponse: indexedHandleFragment(eventIndex: 1), requestId: requestId)
+        assertExpectedEvents(ignoreUnexpectedEvents: true)
+
+        let captured = orderQueue.sync { dispatchOrder }
+        let completionIndex = captured.firstIndex { $0.source == TestConstants.EventSource.CONTENT_COMPLETE && $0.parentID == e0.id }
+        let handle1Index = captured.firstIndex { $0.source == "pairedeventexample" }
+
+        XCTAssertNotNil(completionIndex, "event 0's completion must be dispatched")
+        XCTAssertNotNil(handle1Index, "index 1's handle must be dispatched")
+        if let completionIndex = completionIndex, let handle1Index = handle1Index {
+            XCTAssertLessThan(completionIndex, handle1Index,
+                              "completion for event 0 must be dispatched before index 1's handle, so a completion listener never observes index 1's data")
+        }
+    }
+
+    func testEarlyCompletionDisabled_completesAllAtStreamClose_legacyParity() {
+        NetworkResponseHandler.earlyPerEventCompletionEnabled = false
+        defer { NetworkResponseHandler.earlyPerEventCompletionEnabled = true }
+
+        let requestId = "req-legacy"
+        let e0 = completionEvent(name: "e0")
+        let e1 = completionEvent(name: "e1")
+        networkResponseHandler.addWaitingEvents(requestId: requestId, batchedEvents: [e0, e1])
+
+        networkResponseHandler.processResponseOnSuccess(jsonResponse: indexedHandleFragment(eventIndex: 0), requestId: requestId)
+        networkResponseHandler.processResponseOnSuccess(jsonResponse: indexedHandleFragment(eventIndex: 1), requestId: requestId)
+        // disabled: no completion until stream close, even though index 1 was observed
+        XCTAssertEqual(0, getDispatchedEventsWith(type: EventType.edge, source: TestConstants.EventSource.CONTENT_COMPLETE, timeout: 1).count)
+
+        networkResponseHandler.processResponseOnComplete(requestId: requestId)
+        let completes = getDispatchedEventsWith(type: EventType.edge, source: TestConstants.EventSource.CONTENT_COMPLETE)
+        XCTAssertEqual(2, completes.count)
+        XCTAssertEqual(e0.id, completes[0].parentID)
+        XCTAssertEqual(e1.id, completes[1].parentID)
+    }
 }

--- a/Tests/FunctionalTests/NetworkResponseHandlerFunctionalTests.swift
+++ b/Tests/FunctionalTests/NetworkResponseHandlerFunctionalTests.swift
@@ -74,8 +74,8 @@ class NetworkResponseHandlerFunctionalTests: TestBase, AnyCodableAsserts {
         assertEqual(expected: expected, actual: dispatchEvents[0])
     }
 
-    func testProcessResponseOnError_WhenOneEventJsonError_dispatchesEvent() {
-        setExpectationEvent(type: TestConstants.EventType.EDGE, source: TestConstants.EventSource.ERROR_RESPONSE_CONTENT, expectedCount: 1)
+    func testProcessResponseOnError_WhenOneEventJsonError_noIndexBatchOfTwo_fansOutToBothEvents() {
+        setExpectationEvent(type: TestConstants.EventType.EDGE, source: TestConstants.EventSource.ERROR_RESPONSE_CONTENT, expectedCount: 2)
         let jsonError = "{\n" +
             "      \"requestId\": \"d81c93e5-7558-4996-a93c-489d550748b8\",\n" +
             "      \"handle\": [],\n" +
@@ -91,9 +91,57 @@ class NetworkResponseHandlerFunctionalTests: TestBase, AnyCodableAsserts {
         networkResponseHandler.addWaitingEvents(requestId: "123", batchedEvents: [event1, event2])
         networkResponseHandler.processResponseOnError(jsonError: jsonError, requestId: "123")
         let dispatchEvents = getDispatchedEventsWith(type: TestConstants.EventType.EDGE, source: TestConstants.EventSource.ERROR_RESPONSE_CONTENT)
+        XCTAssertEqual(2, dispatchEvents.count)
+
+        // No eventIndex on a batch of 2 -> fanned out to both waiting events
+        XCTAssertEqual(event1.id, dispatchEvents[0].parentID)
+        XCTAssertEqual(event2.id, dispatchEvents[1].parentID)
+
+        let expected_event1 = """
+        {
+          "requestEventId": "\(event1.id.uuidString)",
+          "requestId": "123",
+          "status": 500,
+          "title": "Failed due to unrecoverable system error: java.lang.IllegalStateException: Expected BEGIN_ARRAY but was BEGIN_OBJECT at path $.commerce.purchases",
+          "type": "https://ns.adobe.com/aep/errors/EXEG-0201-503"
+        }
+        """
+
+        assertEqual(expected: expected_event1, actual: dispatchEvents[0])
+
+        let expected_event2 = """
+        {
+          "requestEventId": "\(event2.id.uuidString)",
+          "requestId": "123",
+          "status": 500,
+          "title": "Failed due to unrecoverable system error: java.lang.IllegalStateException: Expected BEGIN_ARRAY but was BEGIN_OBJECT at path $.commerce.purchases",
+          "type": "https://ns.adobe.com/aep/errors/EXEG-0201-503"
+        }
+        """
+
+        assertEqual(expected: expected_event2, actual: dispatchEvents[1])
+    }
+
+    func testProcessResponseOnError_WhenOneEventJsonError_singleWaitingEvent_routesToThatEvent() {
+        setExpectationEvent(type: TestConstants.EventType.EDGE, source: TestConstants.EventSource.ERROR_RESPONSE_CONTENT, expectedCount: 1)
+        let jsonError = "{\n" +
+            "      \"requestId\": \"d81c93e5-7558-4996-a93c-489d550748b8\",\n" +
+            "      \"handle\": [],\n" +
+            "      \"errors\": [\n" +
+            "        {\n" +
+            "          \"status\": 500,\n" +
+            "          \"type\": \"https://ns.adobe.com/aep/errors/EXEG-0201-503\",\n" +
+            "          \"title\": \"Failed due to unrecoverable system error: java.lang.IllegalStateException: Expected BEGIN_ARRAY but was BEGIN_OBJECT at path $.commerce.purchases\"\n"
+            +
+            "        }\n" +
+            "      ]\n" +
+            "    }"
+        networkResponseHandler.addWaitingEvents(requestId: "123", batchedEvents: [event1])
+        networkResponseHandler.processResponseOnError(jsonError: jsonError, requestId: "123")
+        let dispatchEvents = getDispatchedEventsWith(type: TestConstants.EventType.EDGE, source: TestConstants.EventSource.ERROR_RESPONSE_CONTENT)
         XCTAssertEqual(1, dispatchEvents.count)
 
-        // Parent ID chained to default event index 0
+        // No eventIndex, exactly one waiting event -> unambiguous; routes to it
         XCTAssertEqual(event1.id, dispatchEvents[0].parentID)
 
         let expected = """
@@ -219,8 +267,8 @@ class NetworkResponseHandlerFunctionalTests: TestBase, AnyCodableAsserts {
 
         assertEqual(expected: expected, actual: dispatchEvents[0])
     }
-    func testProcessResponseOnError_WhenTwoEventJsonError_dispatchesTwoEvents() {
-        setExpectationEvent(type: TestConstants.EventType.EDGE, source: TestConstants.EventSource.ERROR_RESPONSE_CONTENT, expectedCount: 2)
+    func testProcessResponseOnError_WhenTwoEventJsonError_noIndexBatchOfTwo_bothErrorsFanOutToBothEvents() {
+        setExpectationEvent(type: TestConstants.EventType.EDGE, source: TestConstants.EventSource.ERROR_RESPONSE_CONTENT, expectedCount: 4)
         let requestId = "123"
         let jsonError = "{\n" +
             "      \"requestId\": \"d81c93e5-7558-4996-a93c-489d550748b8\",\n" +
@@ -243,12 +291,13 @@ class NetworkResponseHandlerFunctionalTests: TestBase, AnyCodableAsserts {
         networkResponseHandler.addWaitingEvents(requestId: requestId, batchedEvents: [event1, event2])
         networkResponseHandler.processResponseOnError(jsonError: jsonError, requestId: requestId)
         let dispatchEvents = getDispatchedEventsWith(type: TestConstants.EventType.EDGE, source: TestConstants.EventSource.ERROR_RESPONSE_CONTENT)
-        XCTAssertEqual(2, dispatchEvents.count)
+        XCTAssertEqual(4, dispatchEvents.count)
 
-        // Event chained to event1 as default event index is 0
+        // First error: no eventIndex on a batch of 2 -> fanned out to both waiting events
         XCTAssertEqual(event1.id, dispatchEvents[0].parentID)
+        XCTAssertEqual(event2.id, dispatchEvents[1].parentID)
 
-        let expected_event1 = """
+        let expected_event1_toEvent1 = """
         {
           "requestEventId": "\(event1.id.uuidString)",
           "requestId": "\(requestId)",
@@ -257,13 +306,24 @@ class NetworkResponseHandlerFunctionalTests: TestBase, AnyCodableAsserts {
           "type": "https://ns.adobe.com/aep/errors/EXEG-0201-503"
         }
         """
+        assertEqual(expected: expected_event1_toEvent1, actual: dispatchEvents[0])
 
-        assertEqual(expected: expected_event1, actual: dispatchEvents[0])
+        let expected_event1_toEvent2 = """
+        {
+          "requestEventId": "\(event2.id.uuidString)",
+          "requestId": "\(requestId)",
+          "status": 0,
+          "title": "Failed due to unrecoverable system error: java.lang.IllegalStateException: Expected BEGIN_ARRAY but was BEGIN_OBJECT at path $.commerce.purchases",
+          "type": "https://ns.adobe.com/aep/errors/EXEG-0201-503"
+        }
+        """
+        assertEqual(expected: expected_event1_toEvent2, actual: dispatchEvents[1])
 
-        // Event chained to event1 as default event index is 0
-        XCTAssertEqual(event1.id, dispatchEvents[1].parentID)
+        // Second error: no eventIndex on a batch of 2 -> fanned out to both waiting events
+        XCTAssertEqual(event1.id, dispatchEvents[2].parentID)
+        XCTAssertEqual(event2.id, dispatchEvents[3].parentID)
 
-        let expected_event2 = """
+        let expected_event2_toEvent1 = """
         {
           "requestEventId": "\(event1.id.uuidString)",
           "requestId": "\(requestId)",
@@ -272,8 +332,18 @@ class NetworkResponseHandlerFunctionalTests: TestBase, AnyCodableAsserts {
           "type": "personalization"
         }
         """
+        assertEqual(expected: expected_event2_toEvent1, actual: dispatchEvents[2])
 
-        assertEqual(expected: expected_event2, actual: dispatchEvents[1])
+        let expected_event2_toEvent2 = """
+        {
+          "requestEventId": "\(event2.id.uuidString)",
+          "requestId": "\(requestId)",
+          "status": 2003,
+          "title": "Failed to process personalization event",
+          "type": "personalization"
+        }
+        """
+        assertEqual(expected: expected_event2_toEvent2, actual: dispatchEvents[3])
     }
     // MARK: processResponseOnSuccess
 
@@ -624,8 +694,8 @@ class NetworkResponseHandlerFunctionalTests: TestBase, AnyCodableAsserts {
         dispatchEvents += getDispatchedEventsWith(type: TestConstants.EventType.EDGE, source: "identity:persist")
         XCTAssertEqual(2, dispatchEvents.count)
         // Verify event 1
-        // Event chained to event1 as default event index is 0
-        XCTAssertEqual(event1.id, dispatchEvents[0].parentID)
+        // No eventIndex in a batch of 2 -> state:store is a global handle type, broadcast with nil parent
+        XCTAssertNil(dispatchEvents[0].parentID)
 
         let expected_event1 = """
         {
@@ -636,7 +706,6 @@ class NetworkResponseHandlerFunctionalTests: TestBase, AnyCodableAsserts {
               "value": "MCMID|29068398647607325310376254630528178721"
             }
           ],
-          "requestEventId": "\(event1.id.uuidString)",
           "requestId": "d81c93e5-7558-4996-a93c-489d550748b8",
           "type": "state:store"
         }
@@ -645,8 +714,8 @@ class NetworkResponseHandlerFunctionalTests: TestBase, AnyCodableAsserts {
         assertEqual(expected: expected_event1, actual: dispatchEvents[0])
 
         // Verify event 2
-        // Event chained to event1 as default event index is 0
-        XCTAssertEqual(event1.id, dispatchEvents[1].parentID)
+        // No eventIndex in a batch of 2, identity:persist is not a known global handle type -> nil parent, skipped attribution
+        XCTAssertNil(dispatchEvents[1].parentID)
 
         let expected_event2 = """
         {
@@ -658,7 +727,6 @@ class NetworkResponseHandlerFunctionalTests: TestBase, AnyCodableAsserts {
               }
             }
           ],
-          "requestEventId": "\(event1.id.uuidString)",
           "requestId": "d81c93e5-7558-4996-a93c-489d550748b8",
           "type": "identity:persist"
         }
@@ -704,8 +772,8 @@ class NetworkResponseHandlerFunctionalTests: TestBase, AnyCodableAsserts {
         XCTAssertEqual(2, dispatchEvents.count)
 
         // Verify event 1
-        // Event chained to event1 as default event index is 0
-        XCTAssertEqual(event1.id, dispatchEvents[0].parentID)
+        // No eventIndex in a batch of 2 -> state:store is a global handle type, broadcast with nil parent
+        XCTAssertNil(dispatchEvents[0].parentID)
 
         let expected_event1 = """
         {
@@ -716,7 +784,6 @@ class NetworkResponseHandlerFunctionalTests: TestBase, AnyCodableAsserts {
               "value": "MCMID|29068398647607325310376254630528178721"
             }
           ],
-          "requestEventId": "\(event1.id.uuidString)",
           "requestId": "123",
           "type": "state:store"
         }
@@ -742,6 +809,60 @@ class NetworkResponseHandlerFunctionalTests: TestBase, AnyCodableAsserts {
         """
 
         assertEqual(expected: expected_event2, actual: dispatchEvents[1])
+    }
+
+    func testProcessResponseOnSuccess_stateStoreHandle_noIndex_batchOfTwo_broadcastsOnce() {
+        // Global handle (state:store) with no eventIndex must be broadcast as exactly ONE event
+        // with nil parentId regardless of batch size.
+        setExpectationEvent(type: TestConstants.EventType.EDGE, source: "state:store", expectedCount: 1)
+        let requestId = "batch-state-req"
+        let jsonResponse = """
+        {
+          "requestId": "\(requestId)",
+          "handle": [
+            {
+              "type": "state:store",
+              "payload": [{"key": "kndctr_org_cluster", "value": "va6", "maxAge": 1800}]
+            }
+          ]
+        }
+        """
+
+        networkResponseHandler.addWaitingEvents(requestId: requestId, batchedEvents: [event1, event2])
+        networkResponseHandler.processResponseOnSuccess(jsonResponse: jsonResponse, requestId: requestId)
+
+        let dispatchEvents = getDispatchedEventsWith(type: TestConstants.EventType.EDGE, source: "state:store")
+        XCTAssertEqual(1, dispatchEvents.count)
+        XCTAssertNil(dispatchEvents[0].parentID)
+    }
+
+    func testDispatchEventWarnings_noIndex_batchOfTwo_fanOutToBothWaitingEvents() {
+        setExpectationEvent(type: TestConstants.EventType.EDGE, source: TestConstants.EventSource.ERROR_RESPONSE_CONTENT, expectedCount: 2)
+        let requestId = "123"
+        let jsonResponse = """
+        {
+          "requestId": "\(requestId)",
+          "handle": [],
+          "errors": [],
+          "warnings": [
+            {
+              "type": "https://ns.adobe.com/aep/errors/EXEG-0204-200",
+              "status": 98,
+              "title": "Some Informative stuff here"
+            }
+          ]
+        }
+        """
+
+        networkResponseHandler.addWaitingEvents(requestId: requestId, batchedEvents: [event1, event2])
+        networkResponseHandler.processResponseOnSuccess(jsonResponse: jsonResponse, requestId: requestId)
+
+        let dispatchEvents = getDispatchedEventsWith(type: TestConstants.EventType.EDGE, source: TestConstants.EventSource.ERROR_RESPONSE_CONTENT)
+        XCTAssertEqual(2, dispatchEvents.count)
+
+        // No eventIndex on a batch of 2 -> fanned out to both waiting events
+        XCTAssertEqual(event1.id, dispatchEvents[0].parentID)
+        XCTAssertEqual(event2.id, dispatchEvents[1].parentID)
     }
 
     func testProcessResponseOnSuccess_WhenEventHandleWithUnknownEventIndex_dispatchesUnpairedEvent() {

--- a/Tests/UnitTests/EdgeBatchingHitQueueTests.swift
+++ b/Tests/UnitTests/EdgeBatchingHitQueueTests.swift
@@ -188,10 +188,13 @@ class EdgeBatchingHitQueueTests: XCTestCase {
             let xdmData: [String: Any] = ["test": "data"]
             let eventData: [String: Any] = ["xdm": xdmData]
             let event = Event(name: "test-event-\(i)", type: EventType.edge, source: EventSource.requestContent, data: eventData)
+            let configuration: [String: Any] = [
+                "edge.configId": "test-config-id",
+                EdgeConstants.SharedState.Configuration.EDGE_BATCHING_ENABLED: batchingEnabled
+            ]
             let edgeEntity = EdgeDataEntity(event: event,
-                                            configuration: AnyCodable.from(dictionary: ["edge.configId": "test-config-id"]) ?? [:],
-                                            identityMap: [:],
-                                            batchingEnabled: batchingEnabled)
+                                            configuration: AnyCodable.from(dictionary: configuration) ?? [:],
+                                            identityMap: [:])
             let data = try? JSONEncoder().encode(edgeEntity)
             entities.append(DataEntity(uniqueIdentifier: "uuid-\(i)", timestamp: Date(), data: data))
         }

--- a/Tests/UnitTests/EdgeBatchingHitQueueTests.swift
+++ b/Tests/UnitTests/EdgeBatchingHitQueueTests.swift
@@ -1,0 +1,214 @@
+//
+// Copyright 2026 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+//
+
+@testable import AEPCore
+@testable import AEPEdge
+import AEPServices
+import AEPTestUtils
+import XCTest
+
+/// Tests for `EdgeBatchingHitQueue` — window-size selection based on the `edge.batching.enabled`
+/// flag snapshotted on the head entity, and queue peek/remove behavior driven by `BatchOutcome`.
+class EdgeBatchingHitQueueTests: XCTestCase {
+    private var mockDataQueue: MockDataQueue!
+    private var mockProcessor: MockBatchProcessor!
+    private var hitQueue: EdgeBatchingHitQueue!
+
+    override func setUp() {
+        mockDataQueue = MockDataQueue()
+        mockProcessor = MockBatchProcessor(networkService: EdgeNetworkService(),
+                                           networkResponseHandler: NetworkResponseHandler(updateLocationHint: { (_: String?, _: TimeInterval?) -> Void in }),
+                                           sharedStateReader: SharedStateReader(getSharedState: { _, _, _ in nil }),
+                                           readyForEvent: { _ in true },
+                                           getImplementationDetails: { nil },
+                                           getLocationHint: { nil })
+        hitQueue = EdgeBatchingHitQueue(dataQueue: mockDataQueue, processor: mockProcessor)
+    }
+
+    override func tearDown() {
+        hitQueue.close()
+    }
+
+    // MARK: - Effective batch-size selection
+
+    func testEffectiveBatchSize_batchingDisabled_processesOneAtATime() {
+        for entity in buildEntities(count: 3, batchingEnabled: false) {
+            _ = mockDataQueue.add(dataEntity: entity)
+        }
+        mockProcessor.outcomeProvider = { entities in .done(resolvedCount: entities.count) }
+
+        hitQueue.beginProcessing()
+        waitUntilQueueEmpty()
+
+        XCTAssertEqual(3, mockProcessor.processBatchCalls.count)
+        for call in mockProcessor.processBatchCalls {
+            XCTAssertEqual(1, call.count)
+        }
+        XCTAssertEqual(0, mockDataQueue.count())
+    }
+
+    func testEffectiveBatchSize_batchingEnabled_peeksFullDepth() {
+        for entity in buildEntities(count: 5, batchingEnabled: true) {
+            _ = mockDataQueue.add(dataEntity: entity)
+        }
+        mockProcessor.outcomeProvider = { entities in .done(resolvedCount: entities.count) }
+
+        hitQueue.beginProcessing()
+        waitUntilQueueEmpty()
+
+        XCTAssertEqual(1, mockProcessor.processBatchCalls.count)
+        XCTAssertEqual(5, mockProcessor.processBatchCalls[0].count)
+    }
+
+    func testEffectiveBatchSize_batchingEnabled_queueLargerThanMax_capsAtMax() {
+        let total = EdgeConstants.Defaults.MAX_BATCH_SIZE + 3
+        for entity in buildEntities(count: total, batchingEnabled: true) {
+            _ = mockDataQueue.add(dataEntity: entity)
+        }
+        mockProcessor.outcomeProvider = { entities in .done(resolvedCount: entities.count) }
+
+        hitQueue.beginProcessing()
+        waitUntilQueueEmpty()
+
+        XCTAssertEqual(2, mockProcessor.processBatchCalls.count)
+        XCTAssertEqual(EdgeConstants.Defaults.MAX_BATCH_SIZE, mockProcessor.processBatchCalls[0].count)
+        XCTAssertEqual(3, mockProcessor.processBatchCalls[1].count)
+    }
+
+    // MARK: - BatchOutcome-driven queue advancement
+
+    /// Regression guard for the event-loss bug: when `processBatch` resolves fewer entities than the
+    /// peeked window (truncation), the queue must remove only the resolved prefix, leaving the rest to
+    /// be re-peeked (and genuinely processed) on the next cycle — not silently dropped.
+    func testDoneOutcome_truncatedResolvedCount_removesOnlyResolvedPrefix_thenReprocessesRemainder() {
+        for entity in buildEntities(count: 3, batchingEnabled: true) {
+            _ = mockDataQueue.add(dataEntity: entity)
+        }
+
+        var callCount = 0
+        mockProcessor.outcomeProvider = { entities in
+            callCount += 1
+            if callCount == 1 {
+                // Simulate truncation: only the first of the 3 peeked entities was actually resolved.
+                return .done(resolvedCount: 1)
+            }
+            return .done(resolvedCount: entities.count)
+        }
+
+        hitQueue.beginProcessing()
+        waitUntilQueueEmpty()
+
+        XCTAssertEqual(2, mockProcessor.processBatchCalls.count)
+        // First cycle peeked the full window of 3, even though only 1 was resolved.
+        XCTAssertEqual(3, mockProcessor.processBatchCalls[0].count)
+        // Second cycle re-peeked exactly the 2 entities left behind — proving they were not lost.
+        XCTAssertEqual(2, mockProcessor.processBatchCalls[1].count)
+        XCTAssertEqual(0, mockDataQueue.count())
+    }
+
+    func testRetryBatchOutcome_doesNotRemoveEntities() {
+        for entity in buildEntities(count: 1, batchingEnabled: false) {
+            _ = mockDataQueue.add(dataEntity: entity)
+        }
+        mockProcessor.outcomeProvider = { _ in .retryBatch(retryInterval: 30) }
+
+        let expectation = XCTestExpectation(description: "processBatch invoked at least once")
+        mockProcessor.onEachCall = { expectation.fulfill() }
+
+        hitQueue.beginProcessing()
+        wait(for: [expectation], timeout: 2)
+
+        // Nothing removed — entity stays for retry.
+        XCTAssertEqual(1, mockDataQueue.count())
+    }
+
+    func testPartialRemoveOutcome_removesResolvedHeadCount_thenReprocessesRemainder() {
+        for entity in buildEntities(count: 3, batchingEnabled: true) {
+            _ = mockDataQueue.add(dataEntity: entity)
+        }
+
+        var callCount = 0
+        mockProcessor.outcomeProvider = { entities in
+            callCount += 1
+            if callCount == 1 {
+                return .partialRemove(resolvedHeadCount: 2, retryInterval: 0.05)
+            }
+            return .done(resolvedCount: entities.count)
+        }
+
+        hitQueue.beginProcessing()
+        waitUntilQueueEmpty()
+
+        XCTAssertEqual(2, mockProcessor.processBatchCalls.count)
+        XCTAssertEqual(3, mockProcessor.processBatchCalls[0].count)
+        XCTAssertEqual(1, mockProcessor.processBatchCalls[1].count)
+        XCTAssertEqual(0, mockDataQueue.count())
+    }
+
+    // MARK: - Suspend
+
+    func testSuspend_stopsProcessing() {
+        hitQueue.suspend()
+        for entity in buildEntities(count: 1, batchingEnabled: false) {
+            hitQueue.queue(entity: entity)
+        }
+
+        let expectation = XCTestExpectation(description: "Wait to confirm no processing occurs")
+        mockProcessor.onEachCall = { XCTFail("processBatch should not be called while suspended") }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) { expectation.fulfill() }
+        wait(for: [expectation], timeout: 1)
+
+        XCTAssertEqual(0, mockProcessor.processBatchCalls.count)
+    }
+
+    // MARK: - Helpers
+
+    /// Polls `mockDataQueue.count()` until it reaches 0, tolerating the fact that `EdgeBatchingHitQueue`
+    /// performs its `remove(n:)` calls asynchronously on its own internal serial queue (so a synchronous
+    /// check immediately after a `processBatch` completion can race ahead of the actual removal).
+    private func waitUntilQueueEmpty(timeout: TimeInterval = 2, file: StaticString = #file, line: UInt = #line) {
+        let predicate = NSPredicate { _, _ in self.mockDataQueue.count() == 0 }
+        let expectation = XCTNSPredicateExpectation(predicate: predicate, object: NSNull())
+        let result = XCTWaiter().wait(for: [expectation], timeout: timeout)
+        XCTAssertEqual(.completed, result, "Timed out waiting for the queue to drain", file: file, line: line)
+    }
+
+    private func buildEntities(count: Int, batchingEnabled: Bool) -> [DataEntity] {
+        var entities: [DataEntity] = []
+        for i in 0..<count {
+            let xdmData: [String: Any] = ["test": "data"]
+            let eventData: [String: Any] = ["xdm": xdmData]
+            let event = Event(name: "test-event-\(i)", type: EventType.edge, source: EventSource.requestContent, data: eventData)
+            let edgeEntity = EdgeDataEntity(event: event,
+                                            configuration: AnyCodable.from(dictionary: ["edge.configId": "test-config-id"]) ?? [:],
+                                            identityMap: [:],
+                                            batchingEnabled: batchingEnabled)
+            let data = try? JSONEncoder().encode(edgeEntity)
+            entities.append(DataEntity(uniqueIdentifier: "uuid-\(i)", timestamp: Date(), data: data))
+        }
+        return entities
+    }
+}
+
+/// Test double for `EdgeHitProcessor` that overrides `processBatch` to return a configurable
+/// `BatchOutcome` instead of performing real network I/O, mirroring Android's Mockito-mocked processor.
+class MockBatchProcessor: EdgeHitProcessor {
+    var processBatchCalls: [[DataEntity]] = []
+    var outcomeProvider: ([DataEntity]) -> BatchOutcome = { .done(resolvedCount: $0.count) }
+    var onEachCall: (() -> Void)?
+
+    override func processBatch(entities: [DataEntity], completion: @escaping (BatchOutcome) -> Void) {
+        processBatchCalls.append(entities)
+        completion(outcomeProvider(entities))
+        onEachCall?()
+    }
+}

--- a/Tests/UnitTests/EdgeBundledBatchingConfigTests.swift
+++ b/Tests/UnitTests/EdgeBundledBatchingConfigTests.swift
@@ -1,0 +1,129 @@
+//
+// Copyright 2026 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+//
+
+@testable import AEPEdge
+import AEPServices
+import XCTest
+
+class EdgeBundledBatchingConfigTests: XCTestCase {
+    private var stubSystemInfoService: StubSystemInfoService!
+    private var originalSystemInfoService: SystemInfoService!
+
+    override func setUp() {
+        originalSystemInfoService = ServiceProvider.shared.systemInfoService
+        stubSystemInfoService = StubSystemInfoService()
+        ServiceProvider.shared.systemInfoService = stubSystemInfoService
+        EdgeBundledBatchingConfig.resetForTesting()
+    }
+
+    override func tearDown() {
+        ServiceProvider.shared.systemInfoService = originalSystemInfoService
+        EdgeBundledBatchingConfig.resetForTesting()
+    }
+
+    func testGet_validJson_returnsParsedDictionary() {
+        stubSystemInfoService.asset = "{\"edge.batching.enabled\": true, \"edge.batching.eventNameAllowlist\": [\"a\", \"b\"], \"edge.batching.maxBatchSize\": 15}"
+
+        let config = EdgeBundledBatchingConfig.get()
+
+        XCTAssertEqual(true, config["edge.batching.enabled"] as? Bool)
+        XCTAssertEqual(["a", "b"], config["edge.batching.eventNameAllowlist"] as? [String])
+        XCTAssertEqual(15, config["edge.batching.maxBatchSize"] as? Int)
+    }
+
+    func testGet_missingFile_returnsEmptyDictionary() {
+        stubSystemInfoService.asset = nil
+
+        XCTAssertTrue(EdgeBundledBatchingConfig.get().isEmpty)
+    }
+
+    func testGet_emptyFile_returnsEmptyDictionary() {
+        stubSystemInfoService.asset = ""
+
+        XCTAssertTrue(EdgeBundledBatchingConfig.get().isEmpty)
+    }
+
+    func testGet_malformedJson_returnsEmptyDictionary() {
+        stubSystemInfoService.asset = "{not valid json"
+
+        XCTAssertTrue(EdgeBundledBatchingConfig.get().isEmpty)
+    }
+
+    func testGet_jsonArrayNotObject_returnsEmptyDictionary() {
+        stubSystemInfoService.asset = "[1, 2, 3]"
+
+        XCTAssertTrue(EdgeBundledBatchingConfig.get().isEmpty)
+    }
+
+    func testGet_calledTwice_readsAssetOnlyOnce() {
+        stubSystemInfoService.asset = "{\"edge.batching.enabled\": true}"
+
+        let firstResult = EdgeBundledBatchingConfig.get()
+
+        // Changing the underlying asset after the first read must not affect subsequent reads - the
+        // parsed result is cached the first time `get()` is called.
+        stubSystemInfoService.asset = "{\"edge.batching.enabled\": false}"
+        let secondResult = EdgeBundledBatchingConfig.get()
+
+        XCTAssertEqual(true, firstResult["edge.batching.enabled"] as? Bool)
+        XCTAssertEqual(true, secondResult["edge.batching.enabled"] as? Bool)
+        XCTAssertEqual(1, stubSystemInfoService.getAssetCallCount)
+    }
+
+    func testResetForTesting_forcesReload() {
+        stubSystemInfoService.asset = "{\"edge.batching.enabled\": true}"
+        _ = EdgeBundledBatchingConfig.get()
+
+        stubSystemInfoService.asset = "{\"edge.batching.enabled\": false}"
+        EdgeBundledBatchingConfig.resetForTesting()
+        let result = EdgeBundledBatchingConfig.get()
+
+        XCTAssertEqual(false, result["edge.batching.enabled"] as? Bool)
+        XCTAssertEqual(2, stubSystemInfoService.getAssetCallCount)
+    }
+}
+
+/// Minimal `SystemInfoService` stub exposing a settable `asset` string returned from
+/// `getAsset(fileName:fileType:) -> String?`, regardless of the requested file name/type. All other
+/// members return placeholder values since `EdgeBundledBatchingConfig` only calls `getAsset`.
+private class StubSystemInfoService: SystemInfoService {
+    var asset: String?
+    private(set) var getAssetCallCount = 0
+
+    func getProperty(for key: String) -> String? { nil }
+
+    func getAsset(fileName: String, fileType: String) -> String? {
+        getAssetCallCount += 1
+        return asset
+    }
+
+    func getAsset(fileName: String, fileType: String) -> [UInt8]? { nil }
+
+    func getDeviceName() -> String { "" }
+    func getMobileCarrierName() -> String? { nil }
+    func getRunMode() -> String { "Application" }
+    func getApplicationName() -> String? { nil }
+    func getApplicationBuildNumber() -> String? { nil }
+    func getApplicationVersionNumber() -> String? { nil }
+    func getOperatingSystemName() -> String { "" }
+    func getOperatingSystemVersion() -> String { "" }
+    func getCanonicalPlatformName() -> String { "" }
+    func getDisplayInformation() -> (width: Int, height: Int) { (0, 0) }
+    func getDefaultUserAgent() -> String { "" }
+    func getActiveLocaleName() -> String { "" }
+    func getSystemLocaleName() -> String { "" }
+    func getDeviceType() -> DeviceType { .UNKNOWN }
+    func getApplicationBundleId() -> String? { nil }
+    func getApplicationVersion() -> String? { nil }
+    func getCurrentOrientation() -> DeviceOrientation { .UNKNOWN }
+    func getDeviceModelNumber() -> String { "" }
+}

--- a/Tests/UnitTests/EdgeDataEntityTests.swift
+++ b/Tests/UnitTests/EdgeDataEntityTests.swift
@@ -1,0 +1,47 @@
+//
+// Copyright 2026 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+//
+
+@testable import AEPCore
+@testable import AEPEdge
+import XCTest
+
+class EdgeDataEntityTests: XCTestCase {
+    private let event = Event(name: "test-event", type: EventType.edge, source: EventSource.requestContent, data: ["xdm": ["test": "data"]])
+
+    func testDecode_currentFormat_decodesBatchingEnabledValue() throws {
+        let entity = EdgeDataEntity(event: event, configuration: [:], identityMap: [:], batchingEnabled: true)
+        let data = try JSONEncoder().encode(entity)
+        let decoded = try JSONDecoder().decode(EdgeDataEntity.self, from: data)
+
+        XCTAssertTrue(decoded.batchingEnabled)
+    }
+
+    /// Simulates a hit persisted before `batchingEnabled` was introduced: the JSON has no such key.
+    /// Decoding must succeed (not throw) and default `batchingEnabled` to `false`.
+    func testDecode_oldFormatWithoutBatchingEnabledKey_defaultsToFalse() throws {
+        let entity = EdgeDataEntity(event: event, configuration: [:], identityMap: [:], batchingEnabled: true)
+        let data = try JSONEncoder().encode(entity)
+
+        guard var json = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            XCTFail("Failed to parse encoded EdgeDataEntity as a JSON object")
+            return
+        }
+        XCTAssertNotNil(json["batchingEnabled"], "Precondition: current format is expected to include the key before we strip it")
+        json.removeValue(forKey: "batchingEnabled")
+
+        let oldFormatData = try JSONSerialization.data(withJSONObject: json)
+        let decoded = try JSONDecoder().decode(EdgeDataEntity.self, from: oldFormatData)
+
+        XCTAssertFalse(decoded.batchingEnabled)
+        XCTAssertEqual(event.id, decoded.event.id)
+    }
+}

--- a/Tests/UnitTests/EdgeDataEntityTests.swift
+++ b/Tests/UnitTests/EdgeDataEntityTests.swift
@@ -12,36 +12,48 @@
 
 @testable import AEPCore
 @testable import AEPEdge
+import AEPServices
 import XCTest
 
 class EdgeDataEntityTests: XCTestCase {
     private let event = Event(name: "test-event", type: EventType.edge, source: EventSource.requestContent, data: ["xdm": ["test": "data"]])
 
-    func testDecode_currentFormat_decodesBatchingEnabledValue() throws {
-        let entity = EdgeDataEntity(event: event, configuration: [:], identityMap: [:], batchingEnabled: true)
+    func testDecode_roundTrip_preservesEventAndConfiguration() throws {
+        let configuration: [String: AnyCodable] = ["edge.configId": AnyCodable("1234")]
+        let entity = EdgeDataEntity(event: event, configuration: configuration, identityMap: [:])
         let data = try JSONEncoder().encode(entity)
         let decoded = try JSONDecoder().decode(EdgeDataEntity.self, from: data)
 
-        XCTAssertTrue(decoded.batchingEnabled)
+        XCTAssertEqual(event.id, decoded.event.id)
+        XCTAssertEqual("1234", decoded.configuration["edge.configId"]?.stringValue)
     }
 
-    /// Simulates a hit persisted before `batchingEnabled` was introduced: the JSON has no such key.
-    /// Decoding must succeed (not throw) and default `batchingEnabled` to `false`.
-    func testDecode_oldFormatWithoutBatchingEnabledKey_defaultsToFalse() throws {
-        let entity = EdgeDataEntity(event: event, configuration: [:], identityMap: [:], batchingEnabled: true)
+    /// The batching keys (`edge.batching.enabled`, `edge.batching.eventNameAllowlist`) are snapshotted
+    /// as ordinary entries inside `configuration`, not a dedicated field, so they must round-trip
+    /// through encode/decode and be readable via `asAnyDictionary` alongside String-valued keys.
+    func testDecode_roundTrip_preservesHeterogeneousBatchingKeys() throws {
+        let configuration: [String: AnyCodable] = [
+            "edge.configId": AnyCodable("1234"),
+            EdgeConstants.SharedState.Configuration.EDGE_BATCHING_ENABLED: AnyCodable(true),
+            EdgeConstants.SharedState.Configuration.EDGE_BATCHING_EVENT_NAME_ALLOWLIST: AnyCodable(["add-to-cart", "checkout"])
+        ]
+        let entity = EdgeDataEntity(event: event, configuration: configuration, identityMap: [:])
         let data = try JSONEncoder().encode(entity)
+        let decoded = try JSONDecoder().decode(EdgeDataEntity.self, from: data)
 
-        guard var json = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
-            XCTFail("Failed to parse encoded EdgeDataEntity as a JSON object")
-            return
-        }
-        XCTAssertNotNil(json["batchingEnabled"], "Precondition: current format is expected to include the key before we strip it")
-        json.removeValue(forKey: "batchingEnabled")
+        let anyDictionary = decoded.configuration.asAnyDictionary
+        XCTAssertEqual("1234", anyDictionary["edge.configId"] as? String)
+        XCTAssertEqual(true, anyDictionary[EdgeConstants.SharedState.Configuration.EDGE_BATCHING_ENABLED] as? Bool)
+        XCTAssertEqual(["add-to-cart", "checkout"], anyDictionary[EdgeConstants.SharedState.Configuration.EDGE_BATCHING_EVENT_NAME_ALLOWLIST] as? [String])
+    }
 
-        let oldFormatData = try JSONSerialization.data(withJSONObject: json)
-        let decoded = try JSONDecoder().decode(EdgeDataEntity.self, from: oldFormatData)
+    /// Simulates a hit persisted before the batching keys existed: `configuration` has neither key.
+    /// `asAnyDictionary` lookups for those keys must return nil rather than throwing or crashing.
+    func testAsAnyDictionary_missingBatchingKeys_returnsNil() throws {
+        let entity = EdgeDataEntity(event: event, configuration: ["edge.configId": AnyCodable("1234")], identityMap: [:])
 
-        XCTAssertFalse(decoded.batchingEnabled)
-        XCTAssertEqual(event.id, decoded.event.id)
+        let anyDictionary = entity.configuration.asAnyDictionary
+        XCTAssertNil(anyDictionary[EdgeConstants.SharedState.Configuration.EDGE_BATCHING_ENABLED])
+        XCTAssertNil(anyDictionary[EdgeConstants.SharedState.Configuration.EDGE_BATCHING_EVENT_NAME_ALLOWLIST])
     }
 }

--- a/Tests/UnitTests/EdgeHitProcessorTests.swift
+++ b/Tests/UnitTests/EdgeHitProcessorTests.swift
@@ -191,7 +191,7 @@ class EdgeHitProcessorTests: XCTestCase, AnyCodableAsserts {
         mockNetworkService.setExpectationForNetworkRequest(url: INTERACT_ENDPOINT_PROD, httpMethod: .post, expectedCount: Int32(EDGE_RECOVERABLE_ERROR_CODES.count))
 
         for code in EDGE_RECOVERABLE_ERROR_CODES {
-            let error = EdgeEventError(title: "test-title", detail: nil, status: code, type: "test-type", report: EdgeErrorReport(eventIndex: 0, errors: nil, requestId: nil, orgId: nil))
+            let error = EdgeResponseError(title: "test-title", detail: nil, status: code, type: "test-type", report: EdgeErrorReport(eventIndex: 0, errors: nil, requestId: nil, orgId: nil))
             let edgeResponse = EdgeResponse(requestId: "test-req-id", handle: nil, errors: [error], warnings: nil)
             let responseData = try? JSONEncoder().encode(edgeResponse)
 
@@ -228,7 +228,7 @@ class EdgeHitProcessorTests: XCTestCase, AnyCodableAsserts {
         mockNetworkService.setExpectationForNetworkRequest(url: INTERACT_ENDPOINT_PROD, httpMethod: .post, expectedCount: Int32(EDGE_RECOVERABLE_ERROR_CODES.count))
 
         for code in EDGE_RECOVERABLE_ERROR_CODES {
-            let error = EdgeEventError(title: "test-title", detail: nil, status: code, type: "test-type", report: EdgeErrorReport(eventIndex: 0, errors: nil, requestId: nil, orgId: nil))
+            let error = EdgeResponseError(title: "test-title", detail: nil, status: code, type: "test-type", report: EdgeErrorReport(eventIndex: 0, errors: nil, requestId: nil, orgId: nil))
             let edgeResponse = EdgeResponse(requestId: "test-req-id", handle: nil, errors: [error], warnings: nil)
             let responseData = try? JSONEncoder().encode(edgeResponse)
 
@@ -619,7 +619,7 @@ class EdgeHitProcessorTests: XCTestCase, AnyCodableAsserts {
         mockNetworkService.setExpectationForNetworkRequest(url: CONSENT_ENDPOINT, httpMethod: .post, expectedCount: Int32(EDGE_RECOVERABLE_ERROR_CODES.count))
 
         for code in EDGE_RECOVERABLE_ERROR_CODES {
-            let error = EdgeEventError(title: "test-title", detail: nil, status: code, type: "test-type", report: EdgeErrorReport(eventIndex: 0, errors: nil, requestId: nil, orgId: nil))
+            let error = EdgeResponseError(title: "test-title", detail: nil, status: code, type: "test-type", report: EdgeErrorReport(eventIndex: 0, errors: nil, requestId: nil, orgId: nil))
             let edgeResponse = EdgeResponse(requestId: "test-req-id", handle: nil, errors: [error], warnings: nil)
             let responseData = try? JSONEncoder().encode(edgeResponse)
 
@@ -1163,6 +1163,173 @@ class EdgeHitProcessorTests: XCTestCase, AnyCodableAsserts {
         }
 
         wait(for: [expectation], timeout: 1)
+    }
+
+    // MARK: - processBatch: 400 explosion (real sendBatchHit/explodeAndResend, not a mock outcome)
+    //
+    // `MockNetworkService`'s response matching ignores query params (only scheme/host/path/method), so a
+    // single mocked response would apply identically to both the initial batch POST and every subsequent
+    // exploded individual resend, since they share the same endpoint. `SequencedResponseNetworkService`
+    // below returns one `HttpConnection` per call, in order, so the batch request and each individual
+    // resend can be given distinct outcomes.
+
+    /// A batch of 3 gets a 400 (nothing ingested); all 3 individual resends then succeed.
+    func testProcessBatch_threeEvents_batch400_explodesToIndividualRequests_allSucceedIndividually() {
+        let batchingEdgeConfig: [String: Any] = [
+            "edge.configId": "test-config-id",
+            EdgeConstants.SharedState.Configuration.EDGE_BATCHING_EVENT_NAME_ALLOWLIST: [experienceEvent.name]
+        ]
+        let entities = (1...3).map { entityIndex -> DataEntity in
+            let edgeEntity = getEdgeDataEntity(event: experienceEvent, configuration: batchingEdgeConfig, identityMap: defaultIdentityMap)
+            return DataEntity(uniqueIdentifier: "test-uuid-\(entityIndex)", timestamp: Date(), data: try? JSONEncoder().encode(edgeEntity))
+        }
+
+        let sequencedService = SequencedResponseNetworkService(responses: [
+            httpConnection(statusCode: HttpResponseCodes.badRequest.rawValue), // batch request
+            httpConnection(statusCode: 200), // entity 1 resend
+            httpConnection(statusCode: 200), // entity 2 resend
+            httpConnection(statusCode: 200) // entity 3 resend
+        ])
+        ServiceProvider.shared.networkService = sequencedService
+
+        let expectation = XCTestExpectation(description: "processBatch completion invoked")
+        hitProcessor.processBatch(entities: entities) { outcome in
+            guard case .done(let resolvedCount) = outcome else {
+                XCTFail("Expected .done outcome, got \(outcome)")
+                return
+            }
+            XCTAssertEqual(3, resolvedCount)
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: 1)
+        XCTAssertEqual(4, sequencedService.requestCount) // 1 batch + 3 individual resends
+    }
+
+    /// A batch of 3 gets a 400; the first individual resend succeeds, the second hits a recoverable error -
+    /// explosion stops there and reports a partial removal with a retry for the remainder (entity 3 is
+    /// never sent).
+    func testProcessBatch_batch400_midExplosion_recoverableErrorOnSecondEntity_producesPartialRemoveWithRetry() {
+        let batchingEdgeConfig: [String: Any] = [
+            "edge.configId": "test-config-id",
+            EdgeConstants.SharedState.Configuration.EDGE_BATCHING_EVENT_NAME_ALLOWLIST: [experienceEvent.name]
+        ]
+        let entities = (1...3).map { entityIndex -> DataEntity in
+            let edgeEntity = getEdgeDataEntity(event: experienceEvent, configuration: batchingEdgeConfig, identityMap: defaultIdentityMap)
+            return DataEntity(uniqueIdentifier: "test-uuid-\(entityIndex)", timestamp: Date(), data: try? JSONEncoder().encode(edgeEntity))
+        }
+
+        let retryTimeout = 30
+        let sequencedService = SequencedResponseNetworkService(responses: [
+            httpConnection(statusCode: HttpResponseCodes.badRequest.rawValue), // batch request
+            httpConnection(statusCode: 200), // entity 1 resend succeeds
+            httpConnection(statusCode: HttpResponseCodes.tooManyRequests.rawValue, headers: ["Retry-After": String(retryTimeout)]) // entity 2 resend, recoverable
+        ])
+        ServiceProvider.shared.networkService = sequencedService
+
+        let expectation = XCTestExpectation(description: "processBatch completion invoked")
+        hitProcessor.processBatch(entities: entities) { outcome in
+            guard case .partialRemove(let resolvedHeadCount, let retryInterval) = outcome else {
+                XCTFail("Expected .partialRemove outcome, got \(outcome)")
+                return
+            }
+            XCTAssertEqual(1, resolvedHeadCount)
+            XCTAssertEqual(TimeInterval(retryTimeout), retryInterval)
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: 1)
+        // 1 batch + entity 1 resend + entity 2 resend; entity 3 must never have been sent.
+        XCTAssertEqual(3, sequencedService.requestCount)
+    }
+
+    /// A batch of 3 gets a 400; the first individual resend gets a terminal (non-recoverable) error and is
+    /// dropped, but explosion continues and resolves the remaining two.
+    func testProcessBatch_batch400_terminalErrorMidExplosion_dropsEntityAndContinuesExplosion() {
+        let batchingEdgeConfig: [String: Any] = [
+            "edge.configId": "test-config-id",
+            EdgeConstants.SharedState.Configuration.EDGE_BATCHING_EVENT_NAME_ALLOWLIST: [experienceEvent.name]
+        ]
+        let entities = (1...3).map { entityIndex -> DataEntity in
+            let edgeEntity = getEdgeDataEntity(event: experienceEvent, configuration: batchingEdgeConfig, identityMap: defaultIdentityMap)
+            return DataEntity(uniqueIdentifier: "test-uuid-\(entityIndex)", timestamp: Date(), data: try? JSONEncoder().encode(edgeEntity))
+        }
+
+        let sequencedService = SequencedResponseNetworkService(responses: [
+            httpConnection(statusCode: HttpResponseCodes.badRequest.rawValue), // batch request
+            httpConnection(statusCode: HttpResponseCodes.badRequest.rawValue), // entity 1 resend, terminal (dropped)
+            httpConnection(statusCode: 200), // entity 2 resend succeeds
+            httpConnection(statusCode: 200) // entity 3 resend succeeds
+        ])
+        ServiceProvider.shared.networkService = sequencedService
+
+        let expectation = XCTestExpectation(description: "processBatch completion invoked")
+        hitProcessor.processBatch(entities: entities) { outcome in
+            guard case .done(let resolvedCount) = outcome else {
+                XCTFail("Expected .done outcome, got \(outcome)")
+                return
+            }
+            XCTAssertEqual(3, resolvedCount)
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: 1)
+        XCTAssertEqual(4, sequencedService.requestCount)
+    }
+
+    /// A "batch" of exactly 1 entity never enters the explosion codepath at all - it delegates straight to
+    /// `processHit`, so a 400 is handled identically to the existing single-event 400 behavior (dropped).
+    func testProcessBatch_singleEntityBatch400_delegatesToProcessHit_dropsWithoutExploding() {
+        let sequencedService = SequencedResponseNetworkService(responses: [
+            httpConnection(statusCode: HttpResponseCodes.badRequest.rawValue)
+        ])
+        ServiceProvider.shared.networkService = sequencedService
+
+        let edgeEntity = getEdgeDataEntity(event: experienceEvent, configuration: defaultEdgeConfig, identityMap: defaultIdentityMap)
+        let entity = DataEntity(uniqueIdentifier: "test-uuid", timestamp: Date(), data: try? JSONEncoder().encode(edgeEntity))
+
+        let expectation = XCTestExpectation(description: "processBatch completion invoked")
+        hitProcessor.processBatch(entities: [entity]) { outcome in
+            guard case .done(let resolvedCount) = outcome else {
+                XCTFail("Expected .done outcome, got \(outcome)")
+                return
+            }
+            XCTAssertEqual(1, resolvedCount)
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: 1)
+        XCTAssertEqual(1, sequencedService.requestCount)
+    }
+
+    private func httpConnection(statusCode: Int, headers: [String: String]? = nil) -> HttpConnection {
+        HttpConnection(
+            data: "{}".data(using: .utf8),
+            response: HTTPURLResponse(url: url, statusCode: statusCode, httpVersion: nil, headerFields: headers),
+            error: nil)
+    }
+}
+
+/// A `Networking` stub that returns one `HttpConnection` per call, in the order provided - unlike
+/// `MockNetworkService`, whose response matching ignores query params and so cannot distinguish a batch
+/// request from its own exploded individual resends against the same endpoint. Calls beyond the number of
+/// provided responses repeat the last one.
+private class SequencedResponseNetworkService: Networking {
+    private let responses: [HttpConnection]
+    private(set) var requestCount = 0
+    private let lock = NSLock()
+
+    init(responses: [HttpConnection]) {
+        self.responses = responses
+    }
+
+    func connectAsync(networkRequest: NetworkRequest, completionHandler: ((HttpConnection) -> Void)?) {
+        lock.lock()
+        let index = min(requestCount, responses.count - 1)
+        requestCount += 1
+        lock.unlock()
+
+        completionHandler?(responses[index])
     }
 }
 

--- a/Tests/UnitTests/EdgeHitProcessorTests.swift
+++ b/Tests/UnitTests/EdgeHitProcessorTests.swift
@@ -1044,10 +1044,16 @@ class EdgeHitProcessorTests: XCTestCase, AnyCodableAsserts {
     // MARK: - processBatch
 
     /// Tests that a batch of 2 ExperienceEvents is sent as a single network request and resolves all of them.
+    /// Batching requires the event's name to be in `edge.batching.eventNameAllowlist`, snapshotted here
+    /// alongside `edge.configId` (opt-in allowlist semantics, matching production).
     func testProcessBatch_twoExperienceEvents_happy_sendsOneNetworkRequest_resolvesBoth() {
-        let edgeEntity1 = getEdgeDataEntity(event: experienceEvent, configuration: defaultEdgeConfig, identityMap: defaultIdentityMap)
+        let batchingEdgeConfig: [String: Any] = [
+            "edge.configId": "test-config-id",
+            EdgeConstants.SharedState.Configuration.EDGE_BATCHING_EVENT_NAME_ALLOWLIST: [experienceEvent.name]
+        ]
+        let edgeEntity1 = getEdgeDataEntity(event: experienceEvent, configuration: batchingEdgeConfig, identityMap: defaultIdentityMap)
         let entity1 = DataEntity(uniqueIdentifier: "test-uuid-1", timestamp: Date(), data: try? JSONEncoder().encode(edgeEntity1))
-        let edgeEntity2 = getEdgeDataEntity(event: experienceEvent, configuration: defaultEdgeConfig, identityMap: defaultIdentityMap)
+        let edgeEntity2 = getEdgeDataEntity(event: experienceEvent, configuration: batchingEdgeConfig, identityMap: defaultIdentityMap)
         let entity2 = DataEntity(uniqueIdentifier: "test-uuid-2", timestamp: Date(), data: try? JSONEncoder().encode(edgeEntity2))
 
         mockNetworkService.setExpectationForNetworkRequest(url: INTERACT_ENDPOINT_PROD, httpMethod: .post)

--- a/Tests/UnitTests/EdgeHitProcessorTests.swift
+++ b/Tests/UnitTests/EdgeHitProcessorTests.swift
@@ -1104,6 +1104,80 @@ class EdgeHitProcessorTests: XCTestCase, AnyCodableAsserts {
         XCTAssertEqual(0, mockNetworkService.getNetworkRequestsWith(url: CONSENT_ENDPOINT, httpMethod: .post).count)
     }
 
+    /// Regression guard for `hasSameRequestConfig`: two allowlisted ExperienceEvents that share the same
+    /// Configuration snapshot but differ in their event-level `config` overrides (one has a
+    /// `datastreamIdOverride`, the other doesn't) must NOT be folded into the same batch request - a
+    /// single request is built entirely from the head's config, so silently including the second entity
+    /// would send its data to the head's datastream instead of its own override.
+    func testProcessBatch_secondEntityHasDifferentDatastreamOverride_truncatesBatchAtBoundary() {
+        let batchingEdgeConfig: [String: Any] = [
+            "edge.configId": "test-config-id",
+            EdgeConstants.SharedState.Configuration.EDGE_BATCHING_EVENT_NAME_ALLOWLIST: [experienceEvent.name]
+        ]
+        let headEdgeEntity = getEdgeDataEntity(event: experienceEvent, configuration: batchingEdgeConfig, identityMap: defaultIdentityMap)
+        let headEntity = DataEntity(uniqueIdentifier: "test-uuid-head", timestamp: Date(), data: try? JSONEncoder().encode(headEdgeEntity))
+        // Same event name (so it passes the allowlist check) but a different event-level config override.
+        let overrideEdgeEntity = getEdgeDataEntity(event: experienceEventWithDatastreamIdOverride, configuration: batchingEdgeConfig, identityMap: defaultIdentityMap)
+        let overrideEntity = DataEntity(uniqueIdentifier: "test-uuid-override", timestamp: Date(), data: try? JSONEncoder().encode(overrideEdgeEntity))
+
+        mockNetworkService.setExpectationForNetworkRequest(url: INTERACT_ENDPOINT_PROD, httpMethod: .post)
+        let expectation = XCTestExpectation(description: "processBatch completion invoked")
+
+        hitProcessor.processBatch(entities: [headEntity, overrideEntity]) { outcome in
+            guard case .done(let resolvedCount) = outcome else {
+                XCTFail("Expected .done outcome, got \(outcome)")
+                return
+            }
+            // Only the head was resolved; the differently-configured entity must be left untouched.
+            XCTAssertEqual(1, resolvedCount)
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: 1)
+        // Only one network request — for the head entity alone via the single-entity path; the
+        // override entity was never folded into this request.
+        XCTAssertEqual(1, mockNetworkService.getNetworkRequestsWith(url: INTERACT_ENDPOINT_PROD, httpMethod: .post).count)
+        let requestString = mockNetworkService.getNetworkRequestsWith(url: INTERACT_ENDPOINT_PROD, httpMethod: .post).first?.url.absoluteString ?? ""
+        XCTAssertTrue(requestString.contains("test-config-id"))
+        XCTAssertFalse(requestString.contains("test-datastream-id-override"))
+    }
+
+    /// Regression guard for `hasSameRequestConfig`: two allowlisted ExperienceEvents enqueued under
+    /// different Configuration snapshots (e.g. `edge.configId` changed between enqueues via
+    /// `MobileCore.updateConfiguration()`) must not be folded into the same batch request.
+    func testProcessBatch_differentConfigurationSnapshot_truncatesBatchAtBoundary() {
+        let firstConfig: [String: Any] = [
+            "edge.configId": "test-config-id-1",
+            EdgeConstants.SharedState.Configuration.EDGE_BATCHING_EVENT_NAME_ALLOWLIST: [experienceEvent.name]
+        ]
+        let secondConfig: [String: Any] = [
+            "edge.configId": "test-config-id-2",
+            EdgeConstants.SharedState.Configuration.EDGE_BATCHING_EVENT_NAME_ALLOWLIST: [experienceEvent.name]
+        ]
+        let headEdgeEntity = getEdgeDataEntity(event: experienceEvent, configuration: firstConfig, identityMap: defaultIdentityMap)
+        let headEntity = DataEntity(uniqueIdentifier: "test-uuid-head", timestamp: Date(), data: try? JSONEncoder().encode(headEdgeEntity))
+        let secondEdgeEntity = getEdgeDataEntity(event: experienceEvent, configuration: secondConfig, identityMap: defaultIdentityMap)
+        let secondEntity = DataEntity(uniqueIdentifier: "test-uuid-second", timestamp: Date(), data: try? JSONEncoder().encode(secondEdgeEntity))
+
+        mockNetworkService.setExpectationForNetworkRequest(url: INTERACT_ENDPOINT_PROD, httpMethod: .post)
+        let expectation = XCTestExpectation(description: "processBatch completion invoked")
+
+        hitProcessor.processBatch(entities: [headEntity, secondEntity]) { outcome in
+            guard case .done(let resolvedCount) = outcome else {
+                XCTFail("Expected .done outcome, got \(outcome)")
+                return
+            }
+            XCTAssertEqual(1, resolvedCount)
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: 1)
+        XCTAssertEqual(1, mockNetworkService.getNetworkRequestsWith(url: INTERACT_ENDPOINT_PROD, httpMethod: .post).count)
+        let requestString = mockNetworkService.getNetworkRequestsWith(url: INTERACT_ENDPOINT_PROD, httpMethod: .post).first?.url.absoluteString ?? ""
+        XCTAssertTrue(requestString.contains("test-config-id-1"))
+        XCTAssertFalse(requestString.contains("test-config-id-2"))
+    }
+
     /// A single ExperienceEvent given to `processBatch` (batch size 1) delegates to the existing
     /// `processHit` path and resolves exactly 1 entity.
     func testProcessBatch_singleExperienceEvent_delegatesToProcessHit_resolvesOne() {

--- a/Tests/UnitTests/EdgeHitProcessorTests.swift
+++ b/Tests/UnitTests/EdgeHitProcessorTests.swift
@@ -1040,6 +1040,124 @@ class EdgeHitProcessorTests: XCTestCase, AnyCodableAsserts {
 
         assertProcessHit(entity: entity, urlString: CONSENT_ENDPOINT, sendsNetworkRequest: false, returns: true)
     }
+
+    // MARK: - processBatch
+
+    /// Tests that a batch of 2 ExperienceEvents is sent as a single network request and resolves all of them.
+    func testProcessBatch_twoExperienceEvents_happy_sendsOneNetworkRequest_resolvesBoth() {
+        let edgeEntity1 = getEdgeDataEntity(event: experienceEvent, configuration: defaultEdgeConfig, identityMap: defaultIdentityMap)
+        let entity1 = DataEntity(uniqueIdentifier: "test-uuid-1", timestamp: Date(), data: try? JSONEncoder().encode(edgeEntity1))
+        let edgeEntity2 = getEdgeDataEntity(event: experienceEvent, configuration: defaultEdgeConfig, identityMap: defaultIdentityMap)
+        let entity2 = DataEntity(uniqueIdentifier: "test-uuid-2", timestamp: Date(), data: try? JSONEncoder().encode(edgeEntity2))
+
+        mockNetworkService.setExpectationForNetworkRequest(url: INTERACT_ENDPOINT_PROD, httpMethod: .post)
+        let expectation = XCTestExpectation(description: "processBatch completion invoked")
+
+        hitProcessor.processBatch(entities: [entity1, entity2]) { outcome in
+            guard case .done(let resolvedCount) = outcome else {
+                XCTFail("Expected .done outcome, got \(outcome)")
+                return
+            }
+            XCTAssertEqual(2, resolvedCount)
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: 1)
+        mockNetworkService.assertAllNetworkRequestExpectations(ignoreUnexpectedRequests: false)
+        XCTAssertEqual(1, mockNetworkService.getNetworkRequestsWith(url: INTERACT_ENDPOINT_PROD, httpMethod: .post).count)
+    }
+
+    /// Regression guard for the queue-remove bug: a mixed window (ExperienceEvent then Consent) must
+    /// truncate the batch at the Consent boundary and report a resolvedCount matching only the
+    /// entities actually sent (1), not the full peeked window (2) — otherwise EdgeBatchingHitQueue's
+    /// DONE handling would remove the untouched Consent entity from the queue without ever processing it.
+    func testProcessBatch_experienceEventFollowedByConsent_resolvesOnlyLeadingExperienceRun() {
+        let edgeEntity = getEdgeDataEntity(event: experienceEvent, configuration: defaultEdgeConfig, identityMap: defaultIdentityMap)
+        let experienceEntity = DataEntity(uniqueIdentifier: "test-uuid-exp", timestamp: Date(), data: try? JSONEncoder().encode(edgeEntity))
+        let consentEdgeEntity = getEdgeDataEntity(event: consentUpdateEvent, configuration: defaultEdgeConfig, identityMap: defaultIdentityMap)
+        let consentEntity = DataEntity(uniqueIdentifier: "test-uuid-consent", timestamp: Date(), data: try? JSONEncoder().encode(consentEdgeEntity))
+
+        mockNetworkService.setExpectationForNetworkRequest(url: INTERACT_ENDPOINT_PROD, httpMethod: .post)
+        let expectation = XCTestExpectation(description: "processBatch completion invoked")
+
+        hitProcessor.processBatch(entities: [experienceEntity, consentEntity]) { outcome in
+            guard case .done(let resolvedCount) = outcome else {
+                XCTFail("Expected .done outcome, got \(outcome)")
+                return
+            }
+            // Only the leading ExperienceEvent was resolved; the Consent entity must be left untouched.
+            XCTAssertEqual(1, resolvedCount)
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: 1)
+        mockNetworkService.assertAllNetworkRequestExpectations(ignoreUnexpectedRequests: false)
+        // Only one network request — for the ExperienceEvent alone; the Consent entity was never sent
+        // in this call (it is left for the next processing cycle to handle via the single-entity path).
+        XCTAssertEqual(1, mockNetworkService.getNetworkRequestsWith(url: INTERACT_ENDPOINT_PROD, httpMethod: .post).count)
+        XCTAssertEqual(0, mockNetworkService.getNetworkRequestsWith(url: CONSENT_ENDPOINT, httpMethod: .post).count)
+    }
+
+    /// A single ExperienceEvent given to `processBatch` (batch size 1) delegates to the existing
+    /// `processHit` path and resolves exactly 1 entity.
+    func testProcessBatch_singleExperienceEvent_delegatesToProcessHit_resolvesOne() {
+        let edgeEntity = getEdgeDataEntity(event: experienceEvent, configuration: defaultEdgeConfig, identityMap: defaultIdentityMap)
+        let entity = DataEntity(uniqueIdentifier: "test-uuid", timestamp: Date(), data: try? JSONEncoder().encode(edgeEntity))
+
+        mockNetworkService.setExpectationForNetworkRequest(url: INTERACT_ENDPOINT_PROD, httpMethod: .post)
+        let expectation = XCTestExpectation(description: "processBatch completion invoked")
+
+        hitProcessor.processBatch(entities: [entity]) { outcome in
+            guard case .done(let resolvedCount) = outcome else {
+                XCTFail("Expected .done outcome, got \(outcome)")
+                return
+            }
+            XCTAssertEqual(1, resolvedCount)
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: 1)
+        mockNetworkService.assertAllNetworkRequestExpectations(ignoreUnexpectedRequests: false)
+    }
+
+    /// A head entity that fails to decode is dropped alone (resolvedCount 1) — even when the peeked
+    /// window contains more entities after it, which must be left untouched for the next cycle.
+    func testProcessBatch_headDecodeFailure_dropsOnlyHead_resolvesOne() {
+        let badEntity = DataEntity(uniqueIdentifier: "bad-uuid", timestamp: Date(), data: nil)
+        let edgeEntity = getEdgeDataEntity(event: experienceEvent, configuration: defaultEdgeConfig, identityMap: defaultIdentityMap)
+        let goodEntity = DataEntity(uniqueIdentifier: "good-uuid", timestamp: Date(), data: try? JSONEncoder().encode(edgeEntity))
+
+        let expectation = XCTestExpectation(description: "processBatch completion invoked")
+
+        hitProcessor.processBatch(entities: [badEntity, goodEntity]) { outcome in
+            guard case .done(let resolvedCount) = outcome else {
+                XCTFail("Expected .done outcome, got \(outcome)")
+                return
+            }
+            XCTAssertEqual(1, resolvedCount)
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: 1)
+        // The good entity must never have been sent in this call.
+        XCTAssertEqual(0, mockNetworkService.getNetworkRequestsWith(url: INTERACT_ENDPOINT_PROD, httpMethod: .post).count)
+    }
+
+    /// An empty entities array resolves 0 entities without crashing.
+    func testProcessBatch_emptyEntities_resolvesZero() {
+        let expectation = XCTestExpectation(description: "processBatch completion invoked")
+
+        hitProcessor.processBatch(entities: []) { outcome in
+            guard case .done(let resolvedCount) = outcome else {
+                XCTFail("Expected .done outcome, got \(outcome)")
+                return
+            }
+            XCTAssertEqual(0, resolvedCount)
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: 1)
+    }
 }
 
 extension URL {

--- a/Tests/UnitTests/EdgeNetworkServiceTests.swift
+++ b/Tests/UnitTests/EdgeNetworkServiceTests.swift
@@ -46,7 +46,7 @@ class EdgeNetworkServiceTests: XCTestCase {
         let expectation = XCTestExpectation(description: "Network callback is invoked")
 
         // Test
-        networkService.doRequest(url: url, requestBody: edgeHitPayload, requestHeaders: [:], streaming: nil, responseCallback: mockResponseCallback, completion: { success, retryInterval in
+        networkService.doRequest(url: url, requestBody: edgeHitPayload, requestHeaders: [:], streaming: nil, responseCallback: mockResponseCallback, completion: { success, retryInterval, _ in
             // Verify
             let networkRequests = self.mockNetworkService.getNetworkRequestsWith(url: self.url, httpMethod: .post)
             XCTAssertEqual(1, networkRequests.count)
@@ -83,7 +83,7 @@ class EdgeNetworkServiceTests: XCTestCase {
                                  requestHeaders: testHeaders,
                                  streaming: nil,
                                  responseCallback: mockResponseCallback,
-                                 completion: { success, retryInterval  in
+                                 completion: { success, retryInterval, _  in
             // verify
             let networkRequests = self.mockNetworkService.getNetworkRequestsWith(url: self.url, httpMethod: .post)
             guard let networkRequest = networkRequests.first else {
@@ -123,7 +123,7 @@ class EdgeNetworkServiceTests: XCTestCase {
                                  requestHeaders: [:],
                                  streaming: nil,
                                  responseCallback: mockResponseCallback,
-                                 completion: { success, retryInterval in
+                                 completion: { success, retryInterval, _ in
                                     // verify
                                     XCTAssertTrue(success)
                                     XCTAssertNil(retryInterval)
@@ -152,7 +152,7 @@ class EdgeNetworkServiceTests: XCTestCase {
                                  requestHeaders: [:],
                                  streaming: nil,
                                  responseCallback: mockResponseCallback,
-                                 completion: { success, retryInterval in
+                                 completion: { success, retryInterval, _ in
                                     // verify
                                     XCTAssertTrue(success)
                                     XCTAssertNil(retryInterval)
@@ -181,7 +181,7 @@ class EdgeNetworkServiceTests: XCTestCase {
                                  requestHeaders: [:],
                                  streaming: nil,
                                  responseCallback: mockResponseCallback,
-                                 completion: { success, retryInterval in
+                                 completion: { success, retryInterval, _ in
                                     // verify
                                     XCTAssertTrue(success)
                                     XCTAssertNil(retryInterval)
@@ -212,7 +212,7 @@ class EdgeNetworkServiceTests: XCTestCase {
                                      requestHeaders: [:],
                                      streaming: nil,
                                      responseCallback: mockResponseCallback,
-                                     completion: { success, retryInterval in
+                                     completion: { success, retryInterval, _ in
                 // verify
                 XCTAssertFalse(success)
                 XCTAssertEqual(60.0, retryInterval)
@@ -244,7 +244,7 @@ class EdgeNetworkServiceTests: XCTestCase {
                                      requestHeaders: [:],
                                      streaming: nil,
                                      responseCallback: mockResponseCallback,
-                                     completion: { success, retryInterval in
+                                     completion: { success, retryInterval, _ in
                                         // verify
                                         XCTAssertFalse(success)
                                         XCTAssertEqual(5.0, retryInterval)
@@ -270,7 +270,7 @@ class EdgeNetworkServiceTests: XCTestCase {
                                  requestHeaders: [:],
                                  streaming: nil,
                                  responseCallback: mockResponseCallback,
-                                 completion: { success, retryInterval in
+                                 completion: { success, retryInterval, _ in
                                     // verify
                                     XCTAssertTrue(success)
                                     XCTAssertNil(retryInterval)
@@ -307,7 +307,7 @@ class EdgeNetworkServiceTests: XCTestCase {
                                      requestHeaders: [:],
                                      streaming: nil,
                                      responseCallback: mockResponseCallback,
-                                     completion: { success, retryInterval in
+                                     completion: { success, retryInterval, _ in
                 // verify
                 XCTAssertTrue(success)
                 XCTAssertNil(retryInterval)
@@ -343,7 +343,7 @@ class EdgeNetworkServiceTests: XCTestCase {
                                  requestHeaders: [:],
                                  streaming: nil,
                                  responseCallback: mockResponseCallback,
-                                 completion: { success, retryInterval in
+                                 completion: { success, retryInterval, _ in
                                     // verify
                                     XCTAssertTrue(success)
                                     XCTAssertNil(retryInterval)
@@ -387,7 +387,7 @@ class EdgeNetworkServiceTests: XCTestCase {
                                  requestHeaders: [:],
                                  streaming: nil,
                                  responseCallback: mockResponseCallback,
-                                 completion: { success, retryInterval in
+                                 completion: { success, retryInterval, _ in
                                     // verify
                                     XCTAssertTrue(success)
                                     XCTAssertNil(retryInterval)
@@ -417,7 +417,7 @@ class EdgeNetworkServiceTests: XCTestCase {
                                  requestHeaders: [:],
                                  streaming: nil,
                                  responseCallback: mockResponseCallback,
-                                 completion: { success, retryInterval in
+                                 completion: { success, retryInterval, _ in
                                     // verify
                                     XCTAssertTrue(success)
                                     XCTAssertNil(retryInterval)
@@ -440,7 +440,7 @@ class EdgeNetworkServiceTests: XCTestCase {
                                                 response: HTTPURLResponse(url: url, statusCode: 503, httpVersion: nil, headerFields: nil),
                                                 error: nil)
         mockNetworkService.setMockResponse(url: url, httpMethod: .post, responseConnection: mockHttpConnection)
-        networkService.doRequest(url: url, requestBody: edgeHitPayload, requestHeaders: [:], streaming: nil, responseCallback: mockResponseCallback, completion: { success, retryInterval in
+        networkService.doRequest(url: url, requestBody: edgeHitPayload, requestHeaders: [:], streaming: nil, responseCallback: mockResponseCallback, completion: { success, retryInterval, _ in
             // verify
             XCTAssertFalse(success) // retry
             XCTAssertEqual(5.0, retryInterval) // default timeout
@@ -475,7 +475,7 @@ class EdgeNetworkServiceTests: XCTestCase {
                                      requestHeaders: [:],
                                      streaming: nil,
                                      responseCallback: mockResponseCallback,
-                                     completion: { success, retryInterval in
+                                     completion: { success, retryInterval, _ in
                 // verify
                 XCTAssertFalse(success) // retry
                 XCTAssertEqual(retryValue.1, retryInterval) // timeout value provided by Retry-After response header
@@ -510,7 +510,7 @@ class EdgeNetworkServiceTests: XCTestCase {
                                      requestHeaders: [:],
                                      streaming: nil,
                                      responseCallback: mockResponseCallback,
-                                     completion: { success, retryInterval in
+                                     completion: { success, retryInterval, _ in
                 // verify
                 XCTAssertFalse(success) // retry
                 XCTAssertEqual(5.0, retryInterval) // default

--- a/Tests/UnitTests/EdgeResponseErrorTests.swift
+++ b/Tests/UnitTests/EdgeResponseErrorTests.swift
@@ -15,7 +15,7 @@ import AEPServices
 import AEPTestUtils
 import XCTest
 
-class EdgeEventErrorTests: XCTestCase, AnyCodableAsserts {
+class EdgeResponseErrorTests: XCTestCase, AnyCodableAsserts {
 
     override func setUp() {
         // Put setup code here. This method is called before the invocation of each test method in the class.
@@ -36,7 +36,7 @@ class EdgeEventErrorTests: XCTestCase, AnyCodableAsserts {
                       """.data(using: .utf8)
 
         // test
-        let error = try? JSONDecoder().decode(EdgeEventError.self, from: jsonData ?? Data())
+        let error = try? JSONDecoder().decode(EdgeResponseError.self, from: jsonData ?? Data())
 
         // verify
         XCTAssertEqual(1, error?.report?.eventIndex)
@@ -69,7 +69,7 @@ class EdgeEventErrorTests: XCTestCase, AnyCodableAsserts {
                       """.data(using: .utf8)
 
         // test
-        let errors = try? JSONDecoder().decode([EdgeEventError].self, from: jsonData ?? Data())
+        let errors = try? JSONDecoder().decode([EdgeResponseError].self, from: jsonData ?? Data())
 
         // verify
         XCTAssertEqual(1, errors?.first?.report?.eventIndex)
@@ -104,7 +104,7 @@ class EdgeEventErrorTests: XCTestCase, AnyCodableAsserts {
                       """.data(using: .utf8)
 
         // test
-        let error = try? JSONDecoder().decode(EdgeEventError.self, from: jsonData ?? Data())
+        let error = try? JSONDecoder().decode(EdgeResponseError.self, from: jsonData ?? Data())
 
         // verify
         XCTAssertEqual("https://ns.adobe.com/aep/errors/EXEG-0104-422", error?.type)
@@ -130,7 +130,7 @@ class EdgeEventErrorTests: XCTestCase, AnyCodableAsserts {
                       """.data(using: .utf8)
 
         // test
-        let error = try? JSONDecoder().decode(EdgeEventError.self, from: jsonData ?? Data())
+        let error = try? JSONDecoder().decode(EdgeResponseError.self, from: jsonData ?? Data())
 
         // verify
         XCTAssertEqual("https://ns.adobe.com/aep/errors/EXEG-0104-422", error?.type)
@@ -141,7 +141,7 @@ class EdgeEventErrorTests: XCTestCase, AnyCodableAsserts {
 
     func testCanEncode_eventError_allParams() {
         let report = EdgeErrorReport(eventIndex: 1, errors: ["error1", "error2"], requestId: "1234", orgId: "abcd")
-        let error = EdgeEventError(title: "Test Error", detail: "details", status: 200, type: "error", report: report)
+        let error = EdgeResponseError(title: "Test Error", detail: "details", status: 200, type: "error", report: report)
 
         let encoded = error.asDictionary()
 
@@ -167,7 +167,7 @@ class EdgeEventErrorTests: XCTestCase, AnyCodableAsserts {
 
     func testCanEncode_eventError_emptyReportNotEncoded() {
         let report = EdgeErrorReport(eventIndex: 1, errors: nil, requestId: nil, orgId: nil)
-        let error = EdgeEventError(title: "Test Error", detail: "details", status: 200, type: "error", report: report)
+        let error = EdgeResponseError(title: "Test Error", detail: "details", status: 200, type: "error", report: report)
 
         XCTAssertFalse(report.shouldEncode()) // EdgeErrorReport is not encoded if it only contains eventIndex
 

--- a/Tests/UnitTests/SharedStateReaderTests.swift
+++ b/Tests/UnitTests/SharedStateReaderTests.swift
@@ -1,0 +1,129 @@
+//
+// Copyright 2026 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+//
+
+@testable import AEPCore
+@testable import AEPEdge
+import AEPServices
+import XCTest
+
+class SharedStateReaderTests: XCTestCase {
+    private var stubSystemInfoService: StubBatchingSystemInfoService!
+    private var originalSystemInfoService: SystemInfoService!
+    private let event = Event(name: "test-event", type: EventType.edge, source: EventSource.requestContent, data: nil)
+
+    override func setUp() {
+        originalSystemInfoService = ServiceProvider.shared.systemInfoService
+        stubSystemInfoService = StubBatchingSystemInfoService()
+        ServiceProvider.shared.systemInfoService = stubSystemInfoService
+        EdgeBundledBatchingConfig.resetForTesting()
+    }
+
+    override func tearDown() {
+        ServiceProvider.shared.systemInfoService = originalSystemInfoService
+        EdgeBundledBatchingConfig.resetForTesting()
+    }
+
+    private func reader(configurationState: [String: Any]?) -> SharedStateReader {
+        SharedStateReader(getSharedState: { _, _, _ in
+            guard let configurationState = configurationState else { return nil }
+            return SharedStateResult(status: .set, value: configurationState)
+        })
+    }
+
+    func testGetEdgeBatchingConfig_keyAbsentFromConfigState_fallsBackToBundledEnabled() {
+        stubSystemInfoService.asset = "{\"edge.batching.enabled\": true}"
+        let config = reader(configurationState: [:]).getEdgeBatchingConfig(event: event)
+
+        XCTAssertEqual(true, config[EdgeConstants.SharedState.Configuration.EDGE_BATCHING_ENABLED] as? Bool)
+    }
+
+    func testGetEdgeBatchingConfig_keyPresentInConfigState_bundledIgnored() {
+        stubSystemInfoService.asset = "{\"edge.batching.enabled\": false}"
+        let config = reader(configurationState: [EdgeConstants.SharedState.Configuration.EDGE_BATCHING_ENABLED: true])
+            .getEdgeBatchingConfig(event: event)
+
+        XCTAssertEqual(true, config[EdgeConstants.SharedState.Configuration.EDGE_BATCHING_ENABLED] as? Bool)
+    }
+
+    func testGetEdgeBatchingConfig_eventNameAllowlist_bundledFallback() {
+        stubSystemInfoService.asset = "{\"edge.batching.eventNameAllowlist\": [\"a\", \"b\"]}"
+        let config = reader(configurationState: [:]).getEdgeBatchingConfig(event: event)
+
+        XCTAssertEqual(["a", "b"], config[EdgeConstants.SharedState.Configuration.EDGE_BATCHING_EVENT_NAME_ALLOWLIST] as? [String])
+    }
+
+    func testGetEdgeBatchingConfig_maxBatchSize_bundledFallback() {
+        stubSystemInfoService.asset = "{\"edge.batching.maxBatchSize\": 15}"
+        let config = reader(configurationState: [:]).getEdgeBatchingConfig(event: event)
+
+        XCTAssertEqual(15, config[EdgeConstants.SharedState.Configuration.EDGE_BATCHING_MAX_BATCH_SIZE] as? Int)
+    }
+
+    func testGetEdgeBatchingConfig_maxBatchSize_configStateWins() {
+        stubSystemInfoService.asset = "{\"edge.batching.maxBatchSize\": 20}"
+        let config = reader(configurationState: [EdgeConstants.SharedState.Configuration.EDGE_BATCHING_MAX_BATCH_SIZE: 5])
+            .getEdgeBatchingConfig(event: event)
+
+        XCTAssertEqual(5, config[EdgeConstants.SharedState.Configuration.EDGE_BATCHING_MAX_BATCH_SIZE] as? Int)
+    }
+
+    func testGetEdgeBatchingConfig_allKeysAbsent_returnsEmptyDictionary() {
+        stubSystemInfoService.asset = nil
+        let config = reader(configurationState: [:]).getEdgeBatchingConfig(event: event)
+
+        XCTAssertTrue(config.isEmpty)
+    }
+
+    func testGetEdgeBatchingConfig_maxBatchSize_wrongType_notSurfaced() {
+        stubSystemInfoService.asset = nil
+        let config = reader(configurationState: [EdgeConstants.SharedState.Configuration.EDGE_BATCHING_MAX_BATCH_SIZE: "not-a-number"])
+            .getEdgeBatchingConfig(event: event)
+
+        XCTAssertNil(config[EdgeConstants.SharedState.Configuration.EDGE_BATCHING_MAX_BATCH_SIZE])
+    }
+
+    func testGetEdgeBatchingConfig_nilConfigurationSharedState_fallsBackToBundled() {
+        stubSystemInfoService.asset = "{\"edge.batching.enabled\": true, \"edge.batching.maxBatchSize\": 12}"
+        let config = reader(configurationState: nil).getEdgeBatchingConfig(event: event)
+
+        XCTAssertEqual(true, config[EdgeConstants.SharedState.Configuration.EDGE_BATCHING_ENABLED] as? Bool)
+        XCTAssertEqual(12, config[EdgeConstants.SharedState.Configuration.EDGE_BATCHING_MAX_BATCH_SIZE] as? Int)
+    }
+}
+
+/// Minimal `SystemInfoService` stub exposing a settable `asset` string, used to control
+/// `EdgeBundledBatchingConfig`'s fallback source without touching the real app bundle.
+private class StubBatchingSystemInfoService: SystemInfoService {
+    var asset: String?
+
+    func getProperty(for key: String) -> String? { nil }
+    func getAsset(fileName: String, fileType: String) -> String? { asset }
+    func getAsset(fileName: String, fileType: String) -> [UInt8]? { nil }
+    func getDeviceName() -> String { "" }
+    func getMobileCarrierName() -> String? { nil }
+    func getRunMode() -> String { "Application" }
+    func getApplicationName() -> String? { nil }
+    func getApplicationBuildNumber() -> String? { nil }
+    func getApplicationVersionNumber() -> String? { nil }
+    func getOperatingSystemName() -> String { "" }
+    func getOperatingSystemVersion() -> String { "" }
+    func getCanonicalPlatformName() -> String { "" }
+    func getDisplayInformation() -> (width: Int, height: Int) { (0, 0) }
+    func getDefaultUserAgent() -> String { "" }
+    func getActiveLocaleName() -> String { "" }
+    func getSystemLocaleName() -> String { "" }
+    func getDeviceType() -> DeviceType { .UNKNOWN }
+    func getApplicationBundleId() -> String? { nil }
+    func getApplicationVersion() -> String? { nil }
+    func getCurrentOrientation() -> DeviceOrientation { .UNKNOWN }
+    func getDeviceModelNumber() -> String { "" }
+}

--- a/eventCatalog.json
+++ b/eventCatalog.json
@@ -1,0 +1,276 @@
+{
+  "edge": [
+    {
+      "name": "AEP Request Event",
+      "enabled": true
+    },
+    {
+      "name": "Edge Request Location Hint",
+      "enabled": true
+    },
+    {
+      "name": "Edge Update Location Hint",
+      "enabled": true
+    },
+    {
+      "name": "Edge Location Hint Response",
+      "enabled": true
+    },
+    {
+      "name": "AEP Response Complete",
+      "enabled": true
+    },
+    {
+      "name": "AEP Response Event Handle",
+      "enabled": true
+    },
+    {
+      "name": "AEP Error Response",
+      "enabled": true
+    }
+  ],
+  "optimize": [
+    {
+      "name": "Optimize Update Propositions Request",
+      "enabled": true
+    },
+    {
+      "name": "Optimize Get Propositions Request",
+      "enabled": true
+    },
+    {
+      "name": "Optimize Clear Propositions Request",
+      "enabled": true
+    },
+    {
+      "name": "Optimize Track Propositions Request",
+      "enabled": true
+    },
+    {
+      "name": "Edge Optimize Personalization Request",
+      "enabled": true
+    },
+    {
+      "name": "Optimize Update Propositions Complete",
+      "enabled": true
+    },
+    {
+      "name": "Optimize Notification",
+      "enabled": true
+    },
+    {
+      "name": "Edge Optimize Proposition Interaction Request",
+      "enabled": true
+    },
+    {
+      "name": "Optimize Response",
+      "enabled": true
+    }
+  ],
+  "messaging": [
+    {
+      "name": "Push to in-app",
+      "enabled": true
+    },
+    {
+      "name": "Push notification interaction event",
+      "enabled": true
+    },
+    {
+      "name": "Update propositions",
+      "enabled": true
+    },
+    {
+      "name": "Get propositions",
+      "enabled": true
+    },
+    {
+      "name": "Track propositions",
+      "enabled": true
+    },
+    {
+      "name": "Write IAM event to history",
+      "enabled": true
+    },
+    {
+      "name": "Refresh in-app messages",
+      "enabled": true
+    },
+    {
+      "name": "Push tracking edge event",
+      "enabled": true
+    },
+    {
+      "name": "Push notification token profile Edge event",
+      "enabled": true
+    },
+    {
+      "name": "Messaging interaction event",
+      "enabled": true
+    },
+    {
+      "name": "Push tracking status event",
+      "enabled": true
+    },
+    {
+      "name": "Retrieve message definitions",
+      "enabled": true
+    },
+    {
+      "name": "Finalize propositions response",
+      "enabled": true
+    },
+    {
+      "name": "Message propositions notification",
+      "enabled": true
+    },
+    {
+      "name": "Message propositions response",
+      "enabled": true
+    },
+    {
+      "name": "Seed content cards",
+      "enabled": false
+    },
+    {
+      "name": "Push Identifier Re-sync",
+      "enabled": true
+    },
+    {
+      "name": "Live Activity push-to-start token (Batched) Re-sync",
+      "enabled": true
+    },
+    {
+      "name": "Live Activity push-to-start token (Batched)",
+      "enabled": true
+    },
+    {
+      "name": "Live Activity update token",
+      "enabled": true
+    },
+    {
+      "name": "Live Activity start event",
+      "enabled": true
+    },
+    {
+      "name": "Live Activity {state}",
+      "enabled": true
+    },
+    {
+      "name": "Live Activity updated",
+      "enabled": true
+    },
+    {
+      "name": "Live Activity Schema ({attributeTypeName})",
+      "enabled": true
+    },
+    {
+      "name": "Live Activity push-to-start token to Edge",
+      "enabled": true
+    },
+    {
+      "name": "Live Activity start to Edge",
+      "enabled": true
+    },
+    {
+      "name": "Live Activity update token to Edge",
+      "enabled": true
+    }
+  ],
+  "media": [
+    {
+      "name": "Media::SessionCreated",
+      "enabled": true
+    },
+    {
+      "name": "Media::CreateTrackerRequest",
+      "enabled": true
+    },
+    {
+      "name": "Media::TrackMedia",
+      "enabled": true
+    }
+  ],
+  "edgeMedia": [
+    {
+      "name": "Media::CreateTrackerRequest",
+      "enabled": true
+    },
+    {
+      "name": "Media::TrackMedia",
+      "enabled": true
+    },
+    {
+      "name": "MediaEdge event - media.sessionStart",
+      "enabled": true
+    },
+    {
+      "name": "MediaEdge event - media.sessionComplete",
+      "enabled": true
+    },
+    {
+      "name": "MediaEdge event - media.sessionEnd",
+      "enabled": true
+    },
+    {
+      "name": "MediaEdge event - media.play",
+      "enabled": true
+    },
+    {
+      "name": "MediaEdge event - media.pauseStart",
+      "enabled": true
+    },
+    {
+      "name": "MediaEdge event - media.ping",
+      "enabled": true
+    },
+    {
+      "name": "MediaEdge event - media.error",
+      "enabled": true
+    },
+    {
+      "name": "MediaEdge event - media.bufferStart",
+      "enabled": true
+    },
+    {
+      "name": "MediaEdge event - media.bitrateChange",
+      "enabled": true
+    },
+    {
+      "name": "MediaEdge event - media.adBreakStart",
+      "enabled": true
+    },
+    {
+      "name": "MediaEdge event - media.adBreakComplete",
+      "enabled": true
+    },
+    {
+      "name": "MediaEdge event - media.adStart",
+      "enabled": true
+    },
+    {
+      "name": "MediaEdge event - media.adSkip",
+      "enabled": true
+    },
+    {
+      "name": "MediaEdge event - media.adComplete",
+      "enabled": true
+    },
+    {
+      "name": "MediaEdge event - media.chapterSkip",
+      "enabled": true
+    },
+    {
+      "name": "MediaEdge event - media.chapterStart",
+      "enabled": true
+    },
+    {
+      "name": "MediaEdge event - media.chapterComplete",
+      "enabled": true
+    },
+    {
+      "name": "MediaEdge event - media.statesUpdate",
+      "enabled": true
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- **eventCatalog.json**: Reference catalog of all 66 named events dispatched across Edge, Optimize, Messaging, Media, and EdgeMedia extensions
- **adb_edgeBatchingConfig.json**: Bundled fallback configuration for Edge batching with eventNameAllowlist (9 events) and maxBatchSize (10)

The event catalog enumerates every named Event the extensions dispatch anywhere in their sources (public API requests, internal responses, network events, Live Activity events, etc.), with an `enabled` flag for tracking. This serves as comprehensive documentation and a single source of truth for event inventory across the SDK.

## Test plan

- ✓ eventCatalog.json validates as well-formed JSON (66 events: 7 edge, 9 optimize, 27 messaging, 3 media, 20 edgeMedia)
- ✓ adb_edgeBatchingConfig.json loaded by EdgeBundledBatchingConfig at app startup and used as per-key fallback for Configuration shared state
- ✓ Existing batching tests (dev_batching branch) continue to pass with allowlist active